### PR TITLE
Add real_estate group to retirement allocation config

### DIFF
--- a/src/lib/ledger/types.ts
+++ b/src/lib/ledger/types.ts
@@ -153,6 +153,12 @@ export const DEFAULT_ALLOCATION_CONFIG: AllocationConfig = {
                 "Assets:3_Retirement:IOL:USD",
                 "Assets:3_Retirement:Mattress"
             ]
+        },
+        real_estate: {
+            expected: 0.0,
+            patterns: [
+                "Assets:3_Retirement:NonLiquid:LoteSantoDomingo"
+            ]
         }
     },
     goals: {


### PR DESCRIPTION
### Motivation
- Include a new `real_estate` retirement allocation group so `Assets:3_Retirement:NonLiquid:LoteSantoDomingo` is reported as its own category and treated as expected 0% (same behavior as `cash`).

### Description
- Add `real_estate` to `DEFAULT_ALLOCATION_CONFIG` in `src/lib/ledger/types.ts` with `expected: 0.0` and the pattern `Assets:3_Retirement:NonLiquid:LoteSantoDomingo` so it appears in the retirement assets breakdown.

### Testing
- Ran unit tests with `npm run test -- --run` and all tests passed. 
- Ran production build with `npm run build` which completed successfully (emitted existing Vite/Rollup warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd7874c648832d801e0e37c1b0cb8e)