### PR TITLE
Add configurable financial-month start day

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { getDatabaseAsync, getCurrentUserId } from './offline/database';
 import { trackChange, triggerBackgroundSync } from './offline/sync';
 import type { Currency, CreditCard, Transaction, RecurringRule, Parameter } from '../types';
-import { formatLocalDate, getTodayLocalDate } from './dates';
+import { getTodayLocalDate, getPeriodRange, getPeriodForDate, cacheMonthStartDay } from './dates';
 import { generateOccurrences, mergeTransactions } from './recurringUtils';
 import { normalizeForComparison } from './utils';
 import { pickRateForDate } from './currency';
@@ -216,12 +216,8 @@ export async function fetchTransactions(monthStart: string): Promise<Transaction
     const db = await getDatabaseAsync();
     const userId = await getUserId();
 
-    // monthStart is already YYYY-MM-01 format, use it directly
-    const startStr = monthStart;
-    // Calculate end of month
-    const [year, month] = monthStart.split('-').map(Number);
-    const endDate = new Date(year, month, 1); // month is 0-indexed, so this gives us first of next month
-    const endStr = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-01`;
+    // monthStart is a period anchor (YYYY-MM or YYYY-MM-01); derive the period window.
+    const { start: startStr, end: endStr } = getPeriodRange(monthStart);
 
     const result = await db.query<Transaction & { exchange_rate_value?: number; credit_card_name?: string }>(`
         SELECT
@@ -268,7 +264,7 @@ export async function fetchTransactions(monthStart: string): Promise<Transaction
     const rules = await fetchRecurringRules();
     let virtual: Transaction[] = [];
     for (const rule of rules) {
-        virtual = virtual.concat(generateOccurrences(rule, monthStart, endStr, rates));
+        virtual = virtual.concat(generateOccurrences(rule, startStr, endStr, rates));
     }
 
     return mergeTransactions(virtual, physical, movedOverrides.rows);
@@ -490,12 +486,10 @@ export async function clearBalancedTransactions(monthStart: string): Promise<num
     const userId = await getUserId();
     const timestamp = now();
 
-    // Calculate end of month
-    const [year, month] = monthStart.split('-').map(Number);
-    const endDate = new Date(year, month, 1);
-    const endStr = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-01`;
+    // monthStart is a period anchor; derive the period window.
+    const { start: startStr, end: endStr } = getPeriodRange(monthStart);
 
-    // Get all balanced transactions for the month
+    // Get all balanced transactions for the period
     const result = await db.query<{ id: string }>(`
         SELECT id FROM transactions
         WHERE user_id = $1
@@ -503,7 +497,7 @@ export async function clearBalancedTransactions(monthStart: string): Promise<num
           AND to_be_balanced = true
           AND date >= $2
           AND date < $3
-    `, [userId, monthStart, endStr]);
+    `, [userId, startStr, endStr]);
 
     // Update each transaction and track changes
     for (const row of result.rows) {
@@ -566,10 +560,8 @@ export async function insertExchangeRate(currencyCode: string, rate: number): Pr
         VALUES ($1, $2, $3, $4, $5)
     `, [id, userId, currencyCode, rate, timestamp]);
 
-    // Repoint transactions from the start of the current month (local operation)
-    const nowDate = new Date();
-    const startOfMonth = new Date(nowDate.getFullYear(), nowDate.getMonth(), 1);
-    const dateStr = formatLocalDate(startOfMonth);
+    // Repoint transactions from the start of the current financial period (local operation)
+    const { start: dateStr } = getPeriodRange(getPeriodForDate(getTodayLocalDate()));
 
     await db.query(`
         UPDATE transactions
@@ -830,17 +822,9 @@ export async function cleanupFutureRecurring(): Promise<void> {
 // ============================================================================
 
 export async function computeMonthBalance(month: string): Promise<{ income: number; expense: number; balance: number; taxes: number }> {
-    // month is already YYYY-MM-01 format, use it directly
-    const [year, monthNum] = month.split('-').map(Number);
-
-    // We fetch a range that includes everything in the month
-    // fetchTransactionsRange uses startDate <= date <= endDate or similar?
-    // Actually fetchTransactionsRange uses t.date < $3, so we need first of NEXT month
-    const nextMonth = monthNum === 12 ? 1 : monthNum + 1;
-    const nextYear = monthNum === 12 ? year + 1 : year;
-    const nextMonthStr = `${nextYear}-${String(nextMonth).padStart(2, '0')}-01`;
-
-    const txs = await fetchTransactionsRange(month, nextMonthStr);
+    // `month` is a period anchor (YYYY-MM or YYYY-MM-01); resolve its half-open window.
+    const { start, end } = getPeriodRange(month);
+    const txs = await fetchTransactionsRange(start, end);
 
     let income = 0;
     let expense = 0;
@@ -879,10 +863,17 @@ export async function fetchParameters(): Promise<Parameter[]> {
         SELECT * FROM parameters WHERE user_id = $1
     `, [userId]);
 
-    return result.rows.map(row => ({
+    const params = result.rows.map(row => ({
         ...row,
         value: typeof row.value === 'string' ? JSON.parse(row.value) : row.value
     }));
+
+    // Mirror the financial-month start day into localStorage so the synchronous
+    // period helpers in dates.ts can read it. Absent → reset to the default (1).
+    const startDayParam = params.find(p => p.key === 'month_start_day');
+    cacheMonthStartDay(startDayParam != null ? Number(startDayParam.value) : null);
+
+    return params;
 }
 
 export async function upsertParameter(key: string, value: unknown): Promise<Parameter> {

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -4,7 +4,13 @@ import {
     formatLocalDate,
     formatLocalMonth,
     parseLocalDate,
-    getTodayLocalDate
+    getTodayLocalDate,
+    getMonthStartDay,
+    cacheMonthStartDay,
+    getPeriodRange,
+    getPeriodForDate,
+    getCurrentPeriodAnchor,
+    getPeriodLabel
 } from './dates';
 
 describe('Date Utilities', () => {
@@ -136,6 +142,134 @@ describe('Date Utilities', () => {
             expect(effective.getMonth()).toBe(2); // March
             expect(effective.getDate()).toBe(5);
             vi.useRealTimers();
+        });
+    });
+});
+
+describe('Financial Period Utilities', () => {
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    describe('getMonthStartDay / cacheMonthStartDay', () => {
+        it('defaults to 1 when unset', () => {
+            expect(getMonthStartDay()).toBe(1);
+        });
+
+        it('reads a cached value', () => {
+            cacheMonthStartDay(15);
+            expect(getMonthStartDay()).toBe(15);
+        });
+
+        it('clamps out-of-range values to [1, 28]', () => {
+            cacheMonthStartDay(40);
+            expect(getMonthStartDay()).toBe(28);
+            cacheMonthStartDay(0);
+            expect(getMonthStartDay()).toBe(1);
+        });
+
+        it('clears back to default when passed null', () => {
+            cacheMonthStartDay(15);
+            cacheMonthStartDay(null);
+            expect(getMonthStartDay()).toBe(1);
+        });
+    });
+
+    describe('getPeriodRange', () => {
+        it('is a plain calendar month when start day is 1 (parity)', () => {
+            expect(getPeriodRange('2026-07')).toEqual({ start: '2026-07-01', end: '2026-08-01' });
+            expect(getPeriodRange('2026-12')).toEqual({ start: '2026-12-01', end: '2027-01-01' });
+        });
+
+        it('shifts to the configured start day', () => {
+            cacheMonthStartDay(15);
+            expect(getPeriodRange('2026-07')).toEqual({ start: '2026-07-15', end: '2026-08-15' });
+        });
+
+        it('handles the year boundary', () => {
+            cacheMonthStartDay(15);
+            expect(getPeriodRange('2026-12')).toEqual({ start: '2026-12-15', end: '2027-01-15' });
+        });
+
+        it('accepts a YYYY-MM-DD anchor (ignores the day part)', () => {
+            cacheMonthStartDay(15);
+            expect(getPeriodRange('2026-07-01')).toEqual({ start: '2026-07-15', end: '2026-08-15' });
+        });
+    });
+
+    describe('getPeriodForDate', () => {
+        it('is the calendar month when start day is 1 (parity)', () => {
+            expect(getPeriodForDate('2026-07-20')).toBe('2026-07');
+            expect(getPeriodForDate('2026-07-01')).toBe('2026-07');
+        });
+
+        it('assigns dates on/after the start day to their own month', () => {
+            cacheMonthStartDay(15);
+            expect(getPeriodForDate('2026-07-15')).toBe('2026-07');
+            expect(getPeriodForDate('2026-07-20')).toBe('2026-07');
+        });
+
+        it('assigns dates before the start day to the previous month', () => {
+            cacheMonthStartDay(15);
+            expect(getPeriodForDate('2026-07-10')).toBe('2026-06');
+        });
+
+        it('handles the year boundary', () => {
+            cacheMonthStartDay(15);
+            expect(getPeriodForDate('2026-01-05')).toBe('2025-12');
+        });
+    });
+
+    describe('getCurrentPeriodAnchor', () => {
+        beforeEach(() => vi.useFakeTimers());
+        afterEach(() => vi.useRealTimers());
+
+        it('returns the anchor month (pinned to the 1st) for today', () => {
+            cacheMonthStartDay(15);
+            vi.setSystemTime(new Date(2026, 6, 3)); // Jul 3 -> before start day -> June period
+            const anchor = getCurrentPeriodAnchor();
+            expect(anchor.getFullYear()).toBe(2026);
+            expect(anchor.getMonth()).toBe(5); // June
+            expect(anchor.getDate()).toBe(1);
+        });
+
+        it('uses the current month once the start day has passed', () => {
+            cacheMonthStartDay(15);
+            vi.setSystemTime(new Date(2026, 6, 20)); // Jul 20 -> July period
+            const anchor = getCurrentPeriodAnchor();
+            expect(anchor.getMonth()).toBe(6); // July
+        });
+    });
+
+    describe('getPeriodLabel (majority of days, tie -> end month)', () => {
+        it('is the calendar month when start day is 1', () => {
+            expect(getPeriodLabel('2026-07')).toBe('July 2026');
+        });
+
+        it('uses the start month when it holds the majority (31-day month, start 15)', () => {
+            cacheMonthStartDay(15);
+            // Jul 15–Aug 14: 17 days in July vs 14 in August -> July
+            expect(getPeriodLabel('2026-07')).toBe('July 2026');
+        });
+
+        it('defaults to the end month on a tie (28-day Feb, start 15)', () => {
+            cacheMonthStartDay(15);
+            // Feb 15–Mar 14 (non-leap): 14 vs 14 -> tie -> March
+            expect(getPeriodLabel('2026-02')).toBe('March 2026');
+        });
+
+        it('uses the start month for a leap February (start 15)', () => {
+            cacheMonthStartDay(15);
+            // Feb 15–Mar 14 (leap): 15 vs 14 -> February
+            expect(getPeriodLabel('2024-02')).toBe('February 2024');
+        });
+
+        it('uses the end month when it holds the majority (start 20)', () => {
+            cacheMonthStartDay(20);
+            // Jul 20–Aug 19: 12 vs 19 -> August
+            expect(getPeriodLabel('2026-07')).toBe('August 2026');
+            // Dec 20–Jan 19: end month rolls into the next year
+            expect(getPeriodLabel('2026-12')).toBe('January 2027');
         });
     });
 });

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -32,6 +32,131 @@ export function getTodayLocalDate(): string {
     return formatLocalDate(new Date());
 }
 
+// ============================================================================
+// Financial period (custom month start day)
+// ============================================================================
+//
+// A "financial period" is a month-length window that can start on an arbitrary
+// day-of-month (the `month_start_day` setting) instead of the 1st. A period is
+// identified by an *anchor* — the YYYY-MM of the calendar month it STARTS in —
+// which is unique and contiguous, so it is safe to use as a navigation/storage
+// key. When the start day is 1 (the default) every helper below collapses to
+// plain calendar-month behaviour.
+//
+// The start day lives in the `parameters` table (synced across devices) but is
+// mirrored into localStorage so these synchronous helpers can read it.
+
+export const MONTH_START_DAY_KEY = 'month_start_day';
+
+/** Reads the configured financial-month start day (1–28). Defaults to 1. */
+export function getMonthStartDay(): number {
+    try {
+        const raw = localStorage.getItem(MONTH_START_DAY_KEY);
+        if (raw) {
+            const day = parseInt(raw, 10);
+            if (!isNaN(day)) return Math.min(28, Math.max(1, day));
+        }
+    } catch {
+        // localStorage unavailable — fall through to the default
+    }
+    return 1;
+}
+
+/** Mirrors the start day into localStorage. Pass null to clear (reset to default). */
+export function cacheMonthStartDay(day: number | null | undefined): void {
+    try {
+        if (day == null) {
+            localStorage.removeItem(MONTH_START_DAY_KEY);
+            return;
+        }
+        const clamped = Math.min(28, Math.max(1, Math.floor(day)));
+        localStorage.setItem(MONTH_START_DAY_KEY, String(clamped));
+    } catch {
+        // localStorage unavailable — no-op
+    }
+}
+
+/**
+ * Half-open date range [start, end) for the period anchored to `anchor`.
+ * `anchor` may be YYYY-MM or YYYY-MM-DD (only year+month are used).
+ * With start day D the period runs from D of the anchor month to D of the
+ * next month (exclusive). D is capped at 28 so the range is always valid.
+ */
+export function getPeriodRange(anchor: string): { start: string; end: string } {
+    const [year, month] = anchor.split('-').map(Number); // month is 1-indexed
+    const day = getMonthStartDay();
+    const start = new Date(year, month - 1, day);
+    const end = new Date(year, month, day); // day D of the following month
+    return { start: formatLocalDate(start), end: formatLocalDate(end) };
+}
+
+/**
+ * Returns the anchor (YYYY-MM) of the period a given YYYY-MM-DD date falls in.
+ * A date on/after the start day belongs to its own calendar month's period;
+ * a date before the start day belongs to the previous month's period.
+ */
+export function getPeriodForDate(dateStr: string): string {
+    const [year, month, day] = dateStr.split('-').map(Number); // month is 1-indexed
+    const startDay = getMonthStartDay();
+    let anchorYear = year;
+    let anchorMonth = month;
+    if (day < startDay) {
+        anchorMonth -= 1;
+        if (anchorMonth < 1) {
+            anchorMonth = 12;
+            anchorYear -= 1;
+        }
+    }
+    return `${anchorYear}-${String(anchorMonth).padStart(2, '0')}`;
+}
+
+/** The anchor Date (pinned to the 1st of the anchor month) for today's period. */
+export function getCurrentPeriodAnchor(): Date {
+    const anchor = getPeriodForDate(getTodayLocalDate());
+    const [year, month] = anchor.split('-').map(Number);
+    return new Date(year, month - 1, 1);
+}
+
+/**
+ * Human label for a period: the calendar month holding the MAJORITY of the
+ * period's days, defaulting to the END month on a tie (~50/50). Display only —
+ * labels are not guaranteed unique across periods, so never key state on them.
+ */
+export function getPeriodLabel(anchor: string): string {
+    const [year, month] = anchor.split('-').map(Number); // month is 1-indexed
+    const startDay = getMonthStartDay();
+    const daysInStartMonth = new Date(year, month, 0).getDate(); // last day of the month
+    const daysFromStartMonth = daysInStartMonth - startDay + 1;
+    const daysInEndMonth = startDay - 1;
+
+    let labelYear = year;
+    let labelMonth = month;
+    if (daysFromStartMonth <= daysInEndMonth) {
+        // Tie or end-month majority → use the end month.
+        labelMonth += 1;
+        if (labelMonth > 12) {
+            labelMonth = 1;
+            labelYear += 1;
+        }
+    }
+    return new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' })
+        .format(new Date(labelYear, labelMonth - 1, 1));
+}
+
+/** Short inclusive date-range label for a period, e.g. "Feb 15 – Mar 14". */
+export function formatPeriodRangeLabel(anchor: string): string {
+    const { start, end } = getPeriodRange(anchor);
+    const startDate = parseLocalDate(start);
+    const endExclusive = parseLocalDate(end);
+    const endInclusive = new Date(
+        endExclusive.getFullYear(),
+        endExclusive.getMonth(),
+        endExclusive.getDate() - 1
+    );
+    const fmt = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+    return `${fmt.format(startDate)} – ${fmt.format(endInclusive)}`;
+}
+
 export function calculateCreditCardEffectiveDate(
     transactionDate: Date,
     closingDay: number,
@@ -77,7 +202,7 @@ export function getPersistentMonth(): Date {
         const d = new Date(year, month - 1, 1);
         if (!isNaN(d.getTime())) return d;
     }
-    return new Date();
+    return getCurrentPeriodAnchor();
 }
 
 export function setPersistentMonth(d: Date): void {

--- a/src/pages/Balance.tsx
+++ b/src/pages/Balance.tsx
@@ -3,7 +3,7 @@ import { fetchTransactionsRange, fetchParameters, fetchLatestRates } from '../li
 import type { Transaction, Parameter, ExchangeRate } from '../types';
 import { Loader2, Calendar, Wallet, PiggyBank } from 'lucide-react';
 import { cn } from '../lib/utils';
-import { formatLocalDate, formatLocalMonth, parseLocalDate } from '../lib/dates';
+import { formatLocalDate, formatLocalMonth, parseLocalDate, getCurrentPeriodAnchor, getPeriodRange, getPeriodForDate, getPeriodLabel } from '../lib/dates';
 
 import { useSyncData } from '../hooks/useSyncData';
 
@@ -20,15 +20,18 @@ const AHORRO_TAG_COLORS = [
 ];
 
 export function Balance() {
-    // Default range: next month to +12 months
+    // Default range: next financial period through +12 periods
     const getInitialRange = () => {
-        const now = new Date();
-        const start = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-        const end = new Date(now.getFullYear(), now.getMonth() + 12, 1);
-        const lastDay = new Date(end.getFullYear(), end.getMonth() + 1, 0);
+        const base = getCurrentPeriodAnchor(); // 1st of the current period's anchor month
+        const fromAnchor = formatLocalMonth(new Date(base.getFullYear(), base.getMonth() + 1, 1));
+        const toAnchor = formatLocalMonth(new Date(base.getFullYear(), base.getMonth() + 12, 1));
+        const { start } = getPeriodRange(fromAnchor);
+        const { end } = getPeriodRange(toAnchor);
+        const lastDay = parseLocalDate(end);
+        lastDay.setDate(lastDay.getDate() - 1); // inclusive last day of the last period
 
         return {
-            from: formatLocalDate(start),
+            from: start,
             to: formatLocalDate(lastDay)
         };
     };
@@ -75,12 +78,12 @@ export function Balance() {
         return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((isCents ? cents / 100 : cents));
     };
 
-    // Monthly breakdown logic
+    // Breakdown logic (grouped by financial period, keyed on the period anchor)
     const monthlyData: Record<string, number> = {};
     let totalBalanceCents = 0;
 
     transactions.forEach(t => {
-        const monthKey = t.date.substring(0, 7); // YYYY-MM (DB dates are strings)
+        const monthKey = getPeriodForDate(t.date); // period anchor (YYYY-MM)
         const rate = t.exchange_rate?.rate || 1;
         const amountCents = t.amount_cents / rate;
         const value = t.direction === 'income' ? amountCents : -amountCents;
@@ -89,44 +92,47 @@ export function Balance() {
         totalBalanceCents += value;
     });
 
-    const breakdown: { month: string; actual: number; budget: number; value: number }[] = [];
-    const start = parseLocalDate(range.from);
-    const end = parseLocalDate(range.to);
+    const breakdown: { month: string; label: string; actual: number; budget: number; value: number }[] = [];
+    const rStart = parseLocalDate(range.from);
+    const rEnd = parseLocalDate(range.to);
 
-    const current = new Date(start.getFullYear(), start.getMonth(), 1);
-    const last = new Date(end.getFullYear(), end.getMonth(), 1);
+    // Iterate every financial period whose anchor falls within the selected range.
+    const startAnchor = getPeriodForDate(range.from);
+    const endAnchor = getPeriodForDate(range.to);
+    let [cy, cm] = startAnchor.split('-').map(Number);
+    const [ey, em] = endAnchor.split('-').map(Number);
 
-    while (current <= last) {
-        const key = formatLocalMonth(current);
+    while (cy < ey || (cy === ey && cm <= em)) {
+        const anchor = `${cy}-${String(cm).padStart(2, '0')}`;
 
-        // Calculate days in this month within the range
-        const mStart = new Date(current.getFullYear(), current.getMonth(), 1);
-        const mEnd = new Date(current.getFullYear(), current.getMonth() + 1, 0);
+        // Days of this period that fall inside the selected range.
+        const { start: pStartStr, end: pEndExclStr } = getPeriodRange(anchor);
+        const pStart = parseLocalDate(pStartStr);
+        const pEnd = parseLocalDate(pEndExclStr);
+        pEnd.setDate(pEnd.getDate() - 1); // inclusive last day
 
-        const rStart = parseLocalDate(range.from);
-        const rEnd = parseLocalDate(range.to);
-
-        const actualStart = mStart > rStart ? mStart : rStart;
-        const actualEnd = mEnd < rEnd ? mEnd : rEnd;
-
-        // Reset to midnight for day calculation
+        const actualStart = pStart > rStart ? pStart : rStart;
+        const actualEnd = pEnd < rEnd ? pEnd : rEnd;
         actualStart.setHours(0, 0, 0, 0);
         actualEnd.setHours(0, 0, 0, 0);
 
         const diffTime = Math.max(0, actualEnd.getTime() - actualStart.getTime());
         const daysInRange = Math.round(diffTime / (1000 * 60 * 60 * 24)) + 1;
 
-        const rawSum = monthlyData[key] || 0;
+        const rawSum = monthlyData[anchor] || 0;
         const budgetCents = apd * daysInRange * 100;
         const adjustedValue = rawSum - budgetCents;
 
         breakdown.push({
-            month: key,
+            month: anchor,
+            label: getPeriodLabel(anchor),
             actual: rawSum,
             budget: budgetCents,
             value: adjustedValue
         });
-        current.setMonth(current.getMonth() + 1);
+
+        cm += 1;
+        if (cm > 12) { cm = 1; cy += 1; }
     }
 
     // Ahorro# breakdown: per-month + per-tag, signed so allocations (expenses) read positive.
@@ -134,7 +140,7 @@ export function Balance() {
     const ahorroTagSet = new Set<string>();
     for (const t of transactions) {
         if (!t.tag?.startsWith('Ahorro#')) continue;
-        const monthKey = t.date.substring(0, 7);
+        const monthKey = getPeriodForDate(t.date);
         const rate = t.exchange_rate?.rate || 1;
         const cents = t.amount_cents / rate;
         const value = t.direction === 'expense' ? cents : -cents;
@@ -156,7 +162,7 @@ export function Balance() {
     const ahorroMaxRowTotal = Math.max(0, ...ahorroRows.map(r => Math.abs(r.total)));
 
     // Total days in range
-    const totalDiffTime = Math.max(0, end.getTime() - start.getTime());
+    const totalDiffTime = Math.max(0, rEnd.getTime() - rStart.getTime());
     const totalDaysInRange = Math.ceil(totalDiffTime / (1000 * 60 * 60 * 24)) + 1;
     const totalActual = totalBalanceCents;
     const totalBudget = apd * totalDaysInRange * 100;
@@ -176,8 +182,12 @@ export function Balance() {
                         <label className="text-xs font-bold text-gray-400 uppercase">From</label>
                         <input
                             type="month"
-                            value={range.from.substring(0, 7)}
-                            onChange={(e) => setRange(prev => ({ ...prev, from: `${e.target.value}-01` }))}
+                            value={getPeriodForDate(range.from)}
+                            onChange={(e) => {
+                                if (!e.target.value) return;
+                                const { start } = getPeriodRange(e.target.value);
+                                setRange(prev => ({ ...prev, from: start }));
+                            }}
                             className="bg-transparent border-none p-0 text-sm font-bold focus:ring-0"
                         />
                     </div>
@@ -186,11 +196,13 @@ export function Balance() {
                         <label className="text-xs font-bold text-gray-400 uppercase">To</label>
                         <input
                             type="month"
-                            value={range.to.substring(0, 7)}
+                            value={getPeriodForDate(range.to)}
                             onChange={(e) => {
-                                const [y, m] = e.target.value.split('-');
-                                const lastDay = new Date(parseInt(y), parseInt(m), 0).getDate();
-                                setRange(prev => ({ ...prev, to: `${e.target.value}-${lastDay}` }));
+                                if (!e.target.value) return;
+                                const { end } = getPeriodRange(e.target.value);
+                                const lastDay = parseLocalDate(end);
+                                lastDay.setDate(lastDay.getDate() - 1); // inclusive last day of the period
+                                setRange(prev => ({ ...prev, to: formatLocalDate(lastDay) }));
                             }}
                             className="bg-transparent border-none p-0 text-sm font-bold focus:ring-0"
                         />
@@ -228,7 +240,7 @@ export function Balance() {
                             {breakdown.map((item) => (
                                 <div key={item.month} className="px-6 py-4 flex flex-col sm:flex-row sm:items-center justify-between hover:bg-gray-50 dark:hover:bg-zinc-700/30 transition-colors gap-4">
                                     <div className="flex flex-col">
-                                        <span className="font-mono text-sm font-bold">{item.month}</span>
+                                        <span className="font-mono text-sm font-bold">{item.label}</span>
                                         <div className="flex gap-3 text-[10px] whitespace-nowrap opacity-60 font-mono">
                                             <span>Actual: {formatUSD(item.actual)}</span>
                                             <span>Budget: -{formatUSD(item.budget)}</span>

--- a/src/pages/CreditReport.tsx
+++ b/src/pages/CreditReport.tsx
@@ -4,21 +4,16 @@ import type { Transaction, CreditCard } from '../types';
 import { Loader2, Calendar, CreditCard as CardIcon, Plus, CheckCircle2, Circle, Edit2, Trash2, ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { TransactionForm } from '../components/TransactionForm';
-import { formatLocalDate, getPersistentMonth, setPersistentMonth, parseLocalDate } from '../lib/dates';
+import { formatLocalDate, getPersistentMonth, setPersistentMonth, parseLocalDate, getCurrentPeriodAnchor, formatLocalMonth, getPeriodRange, getPeriodLabel, formatPeriodRangeLabel } from '../lib/dates';
 import { useSyncData } from '../hooks/useSyncData';
 
 export function CreditReport() {
-    // Default logic: next month if > 15, current month if <= 15
+    // Default to the current financial period (which already reflects the
+    // configured month start day); card transactions land here via their payment day.
     const getInitialMonth = () => {
         const saved = localStorage.getItem('selected_month');
         if (saved) return getPersistentMonth();
-
-        const now = new Date();
-        const d = new Date(now.getFullYear(), now.getMonth(), 1);
-        if (now.getDate() > 15) {
-            d.setMonth(d.getMonth() + 1);
-        }
-        return d;
+        return getCurrentPeriodAnchor();
     };
 
     const [currentMonth, setCurrentMonth] = useState(getInitialMonth());
@@ -60,8 +55,12 @@ export function CreditReport() {
         if (!selectedCardId) return;
         setIsLoading(true);
         try {
-            const startStr = formatLocalDate(new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1));
-            const endStr = formatLocalDate(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0));
+            // fetchCreditTransactions is inclusive on both ends, so convert the
+            // period's exclusive end into the last day of the period.
+            const { start: startStr, end: endExclusive } = getPeriodRange(formatLocalMonth(currentMonth));
+            const endDate = parseLocalDate(endExclusive);
+            endDate.setDate(endDate.getDate() - 1);
+            const endStr = formatLocalDate(endDate);
 
             const txs = await fetchCreditTransactions(selectedCardId, startStr, endStr);
             setTransactions(txs);
@@ -219,7 +218,7 @@ export function CreditReport() {
                         Credit Report
                     </h1>
                     <p className="text-sm text-gray-500 font-mono">
-                        🐷 PERIOD: {currentMonth.getFullYear()}-{String(currentMonth.getMonth() + 1).padStart(2, '0')}
+                        🐷 PERIOD: {formatPeriodRangeLabel(formatLocalMonth(currentMonth))}
                     </p>
                 </div>
 
@@ -229,7 +228,7 @@ export function CreditReport() {
                             <ChevronLeft className="w-4 h-4" />
                         </button>
                         <span className="text-sm font-bold min-w-[100px] text-center">
-                            {new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric' }).format(currentMonth)}
+                            {getPeriodLabel(formatLocalMonth(currentMonth))}
                         </span>
                         <button onClick={() => changeMonth(1)} className="p-1 hover:bg-gray-100 dark:hover:bg-zinc-700 rounded transition-colors">
                             <ChevronRight className="w-4 h-4" />

--- a/src/pages/MoneyChecker.tsx
+++ b/src/pages/MoneyChecker.tsx
@@ -3,7 +3,7 @@ import { fetchParameters, fetchLatestRates, fetchTransactions, upsertParameter, 
 import type { ExchangeRate } from '../types';
 import { Loader2, Plus, Trash2, Wallet, ArrowRightLeft, Settings2, CheckCircle2, Scale } from 'lucide-react';
 import { cn } from '../lib/utils';
-import { formatLocalDate, getTodayLocalDate } from '../lib/dates';
+import { formatLocalDate, getTodayLocalDate, getPeriodForDate } from '../lib/dates';
 
 import { useSyncData } from '../hooks/useSyncData';
 
@@ -78,10 +78,9 @@ export function MoneyChecker() {
                 setLatestRates(rates as ExchangeRate[]);
                 setAvailableCurrencies(currenciesData.map(c => c.code));
 
-                // Expected cash (same as Overview for current month until today)
+                // Expected cash (same as Overview for the current period until today)
                 const today = new Date();
-                const monthStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-01`;
-                const txs = await fetchTransactions(monthStr);
+                const txs = await fetchTransactions(getPeriodForDate(formatLocalDate(today)));
                 const todayStr = formatLocalDate(today);
 
                 const cashUntilToday = txs

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -7,7 +7,7 @@ import { CategoryPieChart } from '../components/charts/CategoryPieChart';
 import { TagBarChart } from '../components/charts/TagBarChart';
 import { aggregateByCategory, aggregateByTag } from '../lib/chartUtils';
 import { DailySpendingChart } from '../components/charts/DailySpendingChart';
-import { formatLocalDate, getPersistentMonth, setPersistentMonth } from '../lib/dates';
+import { formatLocalDate, getTodayLocalDate, formatLocalMonth, parseLocalDate, getPeriodRange, getPeriodForDate, getPeriodLabel, formatPeriodRangeLabel, getPersistentMonth, setPersistentMonth } from '../lib/dates';
 
 import { useSyncData } from '../hooks/useSyncData';
 
@@ -163,9 +163,7 @@ export function Overview() {
         load();
     }, [currentMonth, lastDataUpdate]);
 
-    const formatMonth = (d: Date) => {
-        return new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' }).format(d);
-    };
+    const formatMonth = (d: Date) => getPeriodLabel(formatLocalMonth(d));
 
     const formatUSD = (cents: number, isCents = true) => {
         return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((isCents ? cents / 100 : cents));
@@ -188,33 +186,42 @@ export function Overview() {
         );
     }, [transactions, visualizationMode, selectedCategory, showTopTagsOnly]);
 
-    // Calculations for the new overview
-    const today = new Date();
-    const currentMonthStart = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
-    const todayMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+    // Calculations for the new overview (period-aware: the "month" may start on
+    // any day-of-month, so all day math is relative to the period boundaries).
+    const anchor = formatLocalMonth(currentMonth);
+    const { start: periodStartStr, end: periodEndExclStr } = getPeriodRange(anchor);
+    const periodStart = parseLocalDate(periodStartStr);
+    const periodEndExcl = parseLocalDate(periodEndExclStr);
+    const MS_PER_DAY = 1000 * 60 * 60 * 24;
+    const periodLength = Math.round((periodEndExcl.getTime() - periodStart.getTime()) / MS_PER_DAY);
 
-    const isPastMonth = currentMonthStart < todayMonthStart;
-    const isCurrentMonth = currentMonthStart.getTime() === todayMonthStart.getTime();
-    const isFutureMonth = currentMonthStart > todayMonthStart;
+    const todayStr = getTodayLocalDate();
+    const currentAnchor = getPeriodForDate(todayStr);
+    const isPastMonth = anchor < currentAnchor;
+    const isCurrentMonth = anchor === currentAnchor;
+    const isFutureMonth = anchor > currentAnchor;
 
-    const dayOfMonth = isCurrentMonth ? today.getDate() : 1;
-    const lastDayOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0).getDate();
-    const remainingDays = lastDayOfMonth - dayOfMonth + 1;
+    // 1-based index of "today" within the period (day 1 for future periods, the
+    // final day for past periods). For a start day of 1 this equals the calendar
+    // day-of-month, preserving the original behaviour.
+    const dayOfMonth = isCurrentMonth
+        ? Math.round((parseLocalDate(todayStr).getTime() - periodStart.getTime()) / MS_PER_DAY) + 1
+        : (isFutureMonth ? 1 : periodLength);
+    const remainingDays = periodLength - dayOfMonth + 1;
 
-    // For "Expected vs Today", we subtract the expected spend for the remaining days of the month.
-    // For a past month, there are no remaining days, so it should equal the total balance.
-    // For the current month, we subtract days *after* today.
+    // For "Expected vs Today", we subtract the expected spend for the remaining
+    // days of the period. Past period → none; current → days strictly after today.
     const effectiveRemainingDays = isCurrentMonth
-        ? Math.max(0, lastDayOfMonth - today.getDate())
-        : (isFutureMonth ? lastDayOfMonth : 0);
+        ? Math.max(0, periodLength - dayOfMonth)
+        : (isFutureMonth ? periodLength : 0);
 
     const differenceWithExpected = totalBalance - (apd * effectiveRemainingDays * 100);
     const perRemainingDay = isPastMonth ? 0 : totalBalance / remainingDays;
 
     const projectionDays = [];
     if (!isPastMonth) {
-        for (let d = dayOfMonth; d <= lastDayOfMonth; d++) {
-            const left = lastDayOfMonth - d + 1;
+        for (let d = dayOfMonth; d <= periodLength; d++) {
+            const left = periodLength - d + 1;
             projectionDays.push({
                 day: d,
                 value: totalBalance / left
@@ -232,7 +239,7 @@ export function Overview() {
                         Financial Overview
                     </h1>
                     <p className="text-sm text-gray-500 font-mono">
-                        🐷 PERIOD: {currentMonth.getFullYear()}-{String(currentMonth.getMonth() + 1).padStart(2, '0')}
+                        🐷 PERIOD: {formatPeriodRangeLabel(formatLocalMonth(currentMonth))}
                     </p>
                 </div>
                 <div className="flex items-center gap-4 bg-white dark:bg-zinc-800 p-2 rounded-lg shadow-sm border border-gray-100 dark:border-zinc-700">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { fetchCreditCards, insertCreditCard, deleteCreditCard, updateCreditCard, fetchCurrencies, fetchLatestRates, insertExchangeRate, fetchParameters, upsertParameter } from '../lib/api';
+import { cacheMonthStartDay } from '../lib/dates';
 import type { CreditCard, Currency, Parameter } from '../types';
 import { Plus, Trash2, CreditCard as CardIcon, RefreshCw, Settings2, PiggyBank, Loader2, Check, AlertCircle } from 'lucide-react';
 import { cn } from '../lib/utils';
@@ -81,6 +82,7 @@ export function SettingsPage() {
 
 function GeneralSettings() {
     const [apd, setApd] = useState<string>('');
+    const [startDay, setStartDay] = useState<string>('1');
     const [isLoading, setIsLoading] = useState(false);
     const [debugEnabled, setDebugEnabled] = useState(false);
     const [debugError, setDebugError] = useState<string | null>(null);
@@ -92,6 +94,8 @@ function GeneralSettings() {
                 const params: Parameter[] = await fetchParameters();
                 const apdParam = params.find(p => p.key === 'amount_per_day');
                 if (apdParam) setApd(apdParam.value.toString());
+                const startDayParam = params.find(p => p.key === 'month_start_day');
+                if (startDayParam) setStartDay(startDayParam.value.toString());
             } catch (err) {
                 console.error(err);
             } finally {
@@ -112,7 +116,12 @@ function GeneralSettings() {
     const handleSave = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
+            const day = Math.min(28, Math.max(1, Math.round(parseFloat(startDay) || 1)));
             await upsertParameter('amount_per_day', parseFloat(apd));
+            await upsertParameter('month_start_day', day);
+            // Update the synchronous cache immediately so period math reflects the change.
+            cacheMonthStartDay(day);
+            setStartDay(String(day));
             alert("Settings saved!");
         } catch (err) {
             console.error(err);
@@ -159,6 +168,25 @@ function GeneralSettings() {
                         </div>
                         <p className="text-xs text-gray-500 mt-1">
                             This base value is used to calculate your expected daily balance.
+                        </p>
+                    </div>
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                            Month Start Day
+                        </label>
+                        <input
+                            type="number"
+                            min="1"
+                            max="28"
+                            step="1"
+                            value={startDay}
+                            onChange={(e) => setStartDay(e.target.value)}
+                            className="w-full p-2 rounded-lg border border-gray-300 dark:border-zinc-600 bg-white dark:bg-zinc-900"
+                            placeholder="1"
+                            required
+                        />
+                        <p className="text-xs text-gray-500 mt-1">
+                            The day your financial month begins (1–28). Use 1 for a regular calendar month.
                         </p>
                     </div>
                     <button

--- a/src/pages/TransactionsList.tsx
+++ b/src/pages/TransactionsList.tsx
@@ -4,7 +4,7 @@ import type { Transaction } from '../types';
 import { Loader2, ChevronLeft, ChevronRight, AlertCircle, Banknote, CreditCard, Edit2, Trash2, X, Calendar, TrendingUp as UpIcon, TrendingDown as DownIcon, Search, Repeat } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { TransactionForm } from '../components/TransactionForm';
-import { formatLocalDate, parseLocalDate, getPersistentMonth, setPersistentMonth } from '../lib/dates';
+import { formatLocalDate, parseLocalDate, formatLocalMonth, getTodayLocalDate, getPeriodForDate, getPeriodLabel, getPersistentMonth, setPersistentMonth } from '../lib/dates';
 
 import { useSyncData } from '../hooks/useSyncData';
 
@@ -20,10 +20,8 @@ export function TransactionsList() {
     const lastDataUpdate = useSyncData();
 
     useEffect(() => {
-        const today = new Date();
-        const isCurrentMonth = currentMonth.getMonth() === today.getMonth() &&
-            currentMonth.getFullYear() === today.getFullYear();
-        setShowFuture(!isCurrentMonth);
+        const isCurrentPeriod = formatLocalMonth(currentMonth) === getPeriodForDate(getTodayLocalDate());
+        setShowFuture(!isCurrentPeriod);
     }, [currentMonth]);
 
     useEffect(() => {
@@ -34,10 +32,7 @@ export function TransactionsList() {
         // ... rest of function
         setIsLoading(true);
         try {
-            const year = currentMonth.getFullYear();
-            const month = String(currentMonth.getMonth() + 1).padStart(2, '0');
-            const monthStr = `${year}-${month}-01`;
-            const data = await fetchTransactions(monthStr);
+            const data = await fetchTransactions(formatLocalMonth(currentMonth));
             setTransactions(data);
         } catch (err) {
             console.error(err);
@@ -58,7 +53,7 @@ export function TransactionsList() {
         setPersistentMonth(prev);
     };
 
-    const monthLabel = currentMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const monthLabel = getPeriodLabel(formatLocalMonth(currentMonth));
 
     const formatCurrency = (cents: number, currency: string) => {
         return new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
## Context

Piggy hard-codes the assumption that a "financial month" **is** a calendar month (day 1 → last day). This PR lets a user configure their month to **start on an arbitrary day-of-month** (e.g. the 15th), so a period runs `Jul 15 → Aug 14` instead of `Jul 1 → Jul 31` — useful when the real budget cycle is tied to a payday.

Scope is the **operational** surface. The **Annual** and **Savings** pages are intentionally left calendar/year based.

## Approach

There was no shared "month range" helper — the `YYYY-MM-01 → next month` idiom was copy-pasted across the data layer and every page. This PR centralizes a **period abstraction** in `src/lib/dates.ts`, then swaps the inline math everywhere for it.

- **`dates.ts`** — new helpers: `getPeriodRange`, `getPeriodForDate`, `getCurrentPeriodAnchor`, `getPeriodLabel`, `formatPeriodRangeLabel`, plus `getMonthStartDay` / `cacheMonthStartDay`. The start day lives in the `parameters` table (synced) and is mirrored into `localStorage` so these synchronous helpers can read it.
- **`api.ts`** — `fetchTransactions`, `computeMonthBalance`, `clearBalancedTransactions`, and the exchange-rate repoint derive their window from `getPeriodRange`. Recurring virtuals and balances follow the new boundaries automatically (no change to `recurringUtils.ts`). `fetchParameters` mirrors the setting into the cache.
- **Pages** — Overview, Transactions, Credit Report, Money Checker, and Balance window/label/bucket via the shared helpers.
- **Settings** — new **Month Start Day** control (1–28).

## Key design decisions

- **Identity vs. label.** A period is identified by its **anchor** (the `YYYY-MM` it starts in) — unique and contiguous, used for navigation/persistence. The **label** is display-only.
- **Label rule** (per product decision): the calendar month holding the **majority** of the period's days, defaulting to the **end** month on a ~50/50 tie. This can make labels collide/skip (e.g. two "March" periods, no "February" at start-day 15), so state is never keyed on the label and the date range is shown alongside it.
- **Credit Report** windows on the already-payment-day-shifted stored date, so a card transaction lands in the period its **payment day** falls in.
- **Backward compatible:** at start day = 1 (the default) every helper collapses to plain calendar-month behaviour, so this ships as a no-op until a user opts in.
- **1–28 only** for v1, to avoid short-month clamping (29–31 would need a clamp policy — documented, deferred).

## Verification

- `npm run build` — clean (tsc).
- `npm test` — **98 passed**, incl. new period-helper tests (start-day 1 parity, start-day 15 incl. the Feb tie → "March", leap Feb, year rollover, current-period anchoring).
- Lint: no new errors introduced (the pre-existing 67 `no-explicit-any`/unused errors on `main` are untouched code).

Manual check suggested: with `month_start_day` unset/1 confirm identical behaviour to today, then set it to 15 and verify period boundaries, labels + ranges, navigation, "days remaining", and that recurring + credit payment-day transactions land in the expected periods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)