### PR TITLE
Hardening: fix the recurring finance 'diffs'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,13 +125,16 @@ Schema defined in `src/lib/offline/schema.ts` - mirrors Supabase tables plus syn
 
 Key RPCs:
 - `compute_month_balance()` - Monthly income/expense totals in USD
-- `ensure_recurring_generated()` - Generate recurring transactions
+- `get_sync_counts()` - Per-table row counts for sync reconciliation
+
+Recurring transactions are generated client-side as virtual occurrences
+(`src/lib/recurringUtils.ts`) — there is no `ensure_recurring_generated` RPC.
 
 ## Deployment
 
 - **Frontend**: GitHub Pages (via `.github/workflows/deploy.yml`)
 - **Backend**: Supabase (PostgreSQL + Auth)
-- **Infrastructure**: AWS Lambda for backups and recurring generation
+- **Infrastructure**: AWS Lambda for weekly database backups
 
 Base URL: `/piggy/` (configured in `vite.config.ts`)
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Piggy follows an **offline-first architecture** where all reads and writes go th
 
 **Backend (`/supabase/`)**
 - **Tables**: transactions, credit_cards, currencies, exchange_rates, recurring_rules, parameters
-- **RPCs**: `compute_month_balance()`, `ensure_recurring_generated()`, `repoint_exchange_rate()`
+- **RPCs**: `compute_month_balance()`, `get_sync_counts()`, `repoint_exchange_rate()`
 - **Security**: Row Level Security policies ensuring users only access their own data
 
 **Infrastructure (`/terraform/`)**
@@ -381,8 +381,10 @@ npm run build
 ### Key Database Functions (RPCs)
 
 - `compute_month_balance(year, month, user_id)`: Calculates monthly income, expenses, and net balance in USD
-- `ensure_recurring_generated(user_id)`: Generates recurring transactions up to 24 months ahead (idempotent)
 - `repoint_exchange_rate(year, month, currency, user_id)`: Updates exchange rate references for a month
+
+> Recurring transactions are generated client-side as virtual occurrences
+> (`src/lib/recurringUtils.ts`); there is no `ensure_recurring_generated` RPC.
 
 ## Savings Feature (Ledger Integration)
 

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -10,7 +10,7 @@ import {
     insertRecurringRule, updateRecurringRule, fetchRecurringRule, migrateFutureTransactions,
     type TransactionInput
 } from '../lib/api';
-import { calculateCreditCardEffectiveDate, getTodayLocalDate, parseLocalDate, formatLocalDate } from '../lib/dates';
+import { calculateCreditCardEffectiveDate, getTodayLocalDate, parseLocalDate, formatLocalDate, shouldDeriveCardEffectiveDate } from '../lib/dates';
 import type { Currency, CreditCard, Direction, PaymentMethod, Transaction } from '../types';
 import { useNavigate } from 'react-router-dom';
 import { cn, normalizeForComparison } from '../lib/utils';
@@ -140,11 +140,25 @@ export function TransactionForm({ initialData, onSuccess, onCancel }: { initialD
             const amountCents = Math.round(parseFloat(amount) * 100);
 
             // Effective Date Logic
+            // Only derive the card effective date from a genuinely new/raw purchase date.
+            // Re-applying it to an already-shifted stored date is non-idempotent and would
+            // silently push the transaction one month forward on every edit (see
+            // shouldDeriveCardEffectiveDate).
             let effectiveDate = parseLocalDate(date);
             if (method === 'card') {
                 const card = creditCards.find(c => c.id === cardId);
                 if (!card) throw new Error("Selected card not found");
-                effectiveDate = calculateCreditCardEffectiveDate(effectiveDate, card.closing_day, card.payment_day);
+                const shouldDerive = shouldDeriveCardEffectiveDate({
+                    isNew: !initialData,
+                    enteredDate: date,
+                    storedDate: initialData?.date,
+                    storedMethod: initialData?.payment_method,
+                    storedCardId: initialData?.credit_card_id,
+                    cardId,
+                });
+                if (shouldDerive) {
+                    effectiveDate = calculateCreditCardEffectiveDate(effectiveDate, card.closing_day, card.payment_day);
+                }
             }
 
             const dateStr = formatLocalDate(effectiveDate);

--- a/src/lib/annualReportUtils.test.ts
+++ b/src/lib/annualReportUtils.test.ts
@@ -3,6 +3,7 @@ import {
     aggregateExpensesByMonth,
     aggregateIncomeByCategory,
     calculateMonthlySummary,
+    calculateTotalTaxes,
     getAvailableYears
 } from './annualReportUtils';
 import type { Transaction } from '../types';
@@ -132,6 +133,19 @@ describe('annualReportUtils', () => {
             expect(feb?.income).toBe(0);
             expect(feb?.expense).toBe(20000);
             expect(feb?.balance).toBe(-20000);
+        });
+    });
+
+    describe('calculateTotalTaxes', () => {
+        it('counts only expense-direction Taxes (ignores income mis-tagged as Taxes)', () => {
+            const mk = (id: string, dir: 'income' | 'expense', cents: number): Transaction => ({
+                id, user_id: 'u1', direction: dir, amount_cents: cents,
+                category: 'Taxes', tag: 't', date: '2024-01-15', note: '',
+                created_at: '', updated_at: '', payment_method: 'cash',
+                currency_code: 'USD', exchange_rate: { rate: 1 }, to_be_balanced: false,
+            });
+            const total = calculateTotalTaxes([mk('a', 'expense', 5000), mk('b', 'income', 3000)]);
+            expect(total).toBe(5000);
         });
     });
 

--- a/src/lib/annualReportUtils.test.ts
+++ b/src/lib/annualReportUtils.test.ts
@@ -83,6 +83,21 @@ describe('annualReportUtils', () => {
             const result = aggregateExpensesByMonth(mockTransactions, 2023);
             expect(result).toHaveLength(12);
         });
+
+        it('rounds once after summing rather than per transaction (no drift)', () => {
+            const mk = (id: string, cents: number): Transaction => ({
+                id, user_id: 'u1', direction: 'expense', amount_cents: cents,
+                category: 'Recreation', tag: 't', date: '2024-03-15', note: '',
+                created_at: '', updated_at: '', payment_method: 'cash',
+                currency_code: 'ARS', exchange_rate: { rate: 3 }, to_be_balanced: false,
+            });
+            // Each row is 100/3 = 33.33: per-transaction rounding would give 33+33=66;
+            // summing first gives round(200/3)=67.
+            const result = aggregateExpensesByMonth([mk('a', 100), mk('b', 100)], 2024);
+            const march = result.find(r => r.month === '2024-03');
+            expect(march?.categories['Recreation']).toBe(67);
+            expect(march?.total).toBe(67);
+        });
     });
 
     describe('aggregateIncomeByCategory', () => {

--- a/src/lib/annualReportUtils.ts
+++ b/src/lib/annualReportUtils.ts
@@ -24,11 +24,16 @@ export interface MonthlySummary {
 }
 
 /**
- * Convert transaction amount to USD cents
+ * Convert a transaction amount to USD cents in FULL precision (no rounding).
+ *
+ * Rounding is deferred to each function's output so we accumulate in full precision
+ * and round once — matching computeMonthBalance and the AnnualReport summary cards.
+ * Rounding per transaction (as before) accumulated up to ~0.5c of error per row, so
+ * the monthly table disagreed with the cards and with the Overview totals.
  */
 function convertToUSD(transaction: Transaction): number {
   const rate = transaction.exchange_rate?.rate || 1;
-  return Math.round(transaction.amount_cents / rate);
+  return transaction.amount_cents / rate;
 }
 
 /**
@@ -88,13 +93,20 @@ export function aggregateExpensesByMonth(
     }
   });
 
-  // Convert to array (already sorted by month due to initialization order)
+  // Convert to array (already sorted by month due to initialization order).
+  // Round each category once at the boundary and derive the total from the rounded
+  // category values so the displayed total always equals the sum of the visible rows.
   const result = Array.from(monthMap.entries())
-    .map(([month, categories]) => ({
-      month,
-      categories,
-      total: Object.values(categories).reduce((sum, val) => sum + val, 0),
-    }));
+    .map(([month, categories]) => {
+      const roundedCategories: Record<string, number> = {};
+      let total = 0;
+      for (const [cat, val] of Object.entries(categories)) {
+        const rounded = Math.round(val);
+        roundedCategories[cat] = rounded;
+        total += rounded;
+      }
+      return { month, categories: roundedCategories, total };
+    });
 
   return result;
 }
@@ -122,14 +134,14 @@ export function aggregateIncomeByCategory(
     categoryMap.set(t.category, current + convertToUSD(t));
   });
 
-  // Calculate total income for percentages
+  // Calculate total income for percentages (full precision).
   const totalIncome = Array.from(categoryMap.values()).reduce((sum, val) => sum + val, 0);
 
-  // Convert to array with percentages
+  // Convert to array with percentages; round the displayed amount once.
   const result = Array.from(categoryMap.entries())
     .map(([category, amount]) => ({
       category,
-      amount,
+      amount: Math.round(amount),
       percentage: totalIncome > 0 ? (amount / totalIncome) * 100 : 0,
     }))
     .sort((a, b) => b.amount - a.amount); // Sort by amount descending
@@ -163,14 +175,14 @@ export function aggregateExpensesByCategory(
     categoryMap.set(t.category, current + convertToUSD(t));
   });
 
-  // Calculate total expense for percentages
+  // Calculate total expense for percentages (full precision).
   const totalExpense = Array.from(categoryMap.values()).reduce((sum, val) => sum + val, 0);
 
-  // Convert to array with percentages
+  // Convert to array with percentages; round the displayed amount once.
   const result = Array.from(categoryMap.entries())
     .map(([category, amount]) => ({
       category,
-      amount,
+      amount: Math.round(amount),
       percentage: totalExpense > 0 ? (amount / totalExpense) * 100 : 0,
     }))
     .filter(item => item.amount > 0) // Only include categories with spending
@@ -219,15 +231,15 @@ export function calculateMonthlySummary(
     }
   });
 
-  // Convert to array with balance
-  // Income is reduced by taxes, expenses exclude taxes
+  // Convert to array with balance. Income is reduced by taxes, expenses exclude taxes.
+  // Round the displayed income and expense once, then derive balance from those rounded
+  // values so each row reconciles (balance === displayed income - displayed expense).
   const result = Array.from(monthMap.entries())
-    .map(([month, data]) => ({
-      month,
-      income: data.income - data.taxes, // Net income after taxes
-      expense: data.expense,            // Expenses excluding taxes
-      balance: (data.income - data.taxes) - data.expense,
-    }));
+    .map(([month, data]) => {
+      const income = Math.round(data.income - data.taxes); // Net income after taxes
+      const expense = Math.round(data.expense);            // Expenses excluding taxes
+      return { month, income, expense, balance: income - expense };
+    });
 
   return result;
 }
@@ -236,9 +248,10 @@ export function calculateMonthlySummary(
  * Calculate total taxes for the year
  */
 export function calculateTotalTaxes(transactions: Transaction[]): number {
-  return transactions
+  const raw = transactions
     .filter(t => t.category === 'Taxes')
     .reduce((sum, t) => sum + convertToUSD(t), 0);
+  return Math.round(raw);
 }
 
 /**

--- a/src/lib/annualReportUtils.ts
+++ b/src/lib/annualReportUtils.ts
@@ -248,8 +248,11 @@ export function calculateMonthlySummary(
  * Calculate total taxes for the year
  */
 export function calculateTotalTaxes(transactions: Transaction[]): number {
+  // Only expense-direction Taxes count. Without the direction guard an income row
+  // mis-categorised as "Taxes" (e.g. a refund) would be subtracted from gross income,
+  // inconsistent with calculateMonthlySummary which only taxes the expense branch.
   const raw = transactions
-    .filter(t => t.category === 'Taxes')
+    .filter(t => t.direction === 'expense' && t.category === 'Taxes')
     .reduce((sum, t) => sum + convertToUSD(t), 0);
   return Math.round(raw);
 }

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as api from './api';
+import { trackChange } from './offline/sync/queue';
 import type { RecurringRule } from '../types';
 
 // Mock the offline database module
@@ -385,6 +386,29 @@ describe('api', () => {
             expect(params[1]).toBe('rule-1');
             expect(params[2]).toBe('2024-01-15');
             expect(params[3]).toBe('test-user-123');
+        });
+    });
+
+    describe('insertExchangeRate', () => {
+        it('repoints affected transactions AND queues those updates for sync', async () => {
+            mockQuery
+                .mockResolvedValueOnce({ rows: [] })                              // INSERT exchange_rates
+                .mockResolvedValueOnce({ rows: [{ id: 'tx-1' }, { id: 'tx-2' }] }); // UPDATE ... RETURNING id
+
+            await api.insertExchangeRate('ARS', 1200);
+
+            const updateCall = mockQuery.mock.calls.find(
+                c => /UPDATE transactions/.test(c[0]) && /exchange_rate_id/.test(c[0])
+            );
+            expect(updateCall).toBeDefined();
+            // Durable repoint: capture affected rows and stamp updated_at so the change syncs.
+            expect(updateCall![0]).toContain('RETURNING id');
+            expect(updateCall![0]).toContain('updated_at');
+
+            // The rate INSERT and every repointed transaction must be tracked for sync.
+            expect(vi.mocked(trackChange)).toHaveBeenCalledWith('exchange_rates', expect.any(String), 'INSERT', expect.any(Object));
+            expect(vi.mocked(trackChange)).toHaveBeenCalledWith('transactions', 'tx-1', 'UPDATE', expect.objectContaining({ exchange_rate_id: expect.any(String) }));
+            expect(vi.mocked(trackChange)).toHaveBeenCalledWith('transactions', 'tx-2', 'UPDATE', expect.objectContaining({ exchange_rate_id: expect.any(String) }));
         });
     });
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -410,6 +410,12 @@ describe('api', () => {
             expect(vi.mocked(trackChange)).toHaveBeenCalledWith('transactions', 'tx-1', 'UPDATE', expect.objectContaining({ exchange_rate_id: expect.any(String) }));
             expect(vi.mocked(trackChange)).toHaveBeenCalledWith('transactions', 'tx-2', 'UPDATE', expect.objectContaining({ exchange_rate_id: expect.any(String) }));
         });
+
+        it('rejects a non-positive or invalid rate', async () => {
+            await expect(api.insertExchangeRate('ARS', 0)).rejects.toThrow(/positive/i);
+            await expect(api.insertExchangeRate('ARS', -5)).rejects.toThrow(/positive/i);
+            await expect(api.insertExchangeRate('ARS', NaN)).rejects.toThrow(/positive/i);
+        });
     });
 
     describe('fetchDistinctTags', () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -545,6 +545,13 @@ export async function fetchExchangeRate(currencyCode: string, date: string): Pro
 }
 
 export async function insertExchangeRate(currencyCode: string, rate: number): Promise<{ id: string; currency_code: string; rate: number }> {
+    // Reject non-positive/invalid rates: a 0 rate would later be swallowed by the
+    // `rate || 1` fallbacks in the balance math and silently value a foreign-currency
+    // amount as if it were USD (e.g. 12,000 ARS shown as $120 instead of ~$10).
+    if (!Number.isFinite(rate) || rate <= 0) {
+        throw new Error('Exchange rate must be a positive number');
+    }
+
     const db = await getDatabaseAsync();
     const userId = await getUserId();
     const id = generateId();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -825,25 +825,6 @@ export async function deleteRecurringRule(id: string): Promise<void> {
 }
 
 // ============================================================================
-// Recurring Generation (Local Implementation)
-// ============================================================================
-
-export async function cleanupFutureRecurring(): Promise<void> {
-    const db = await getDatabaseAsync();
-    const userId = await getUserId();
-    const today = getTodayLocalDate();
-
-    await db.query(`
-        UPDATE transactions
-        SET deleted_at = $1
-        WHERE user_id = $2
-          AND recurring_rule_id IS NOT NULL
-          AND date >= $3
-          AND original_date IS NULL
-    `, [now(), userId, today]);
-}
-
-// ============================================================================
 // Month Balance (Local Computation)
 // ============================================================================
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -560,18 +560,34 @@ export async function insertExchangeRate(currencyCode: string, rate: number): Pr
         VALUES ($1, $2, $3, $4, $5)
     `, [id, userId, currencyCode, rate, timestamp]);
 
-    // Repoint transactions from the start of the current financial period (local operation)
+    // Repoint transactions from the start of the current financial period to the new rate.
     const { start: dateStr } = getPeriodRange(getPeriodForDate(getTodayLocalDate()));
 
-    await db.query(`
+    const repointed = await db.query<{ id: string }>(`
         UPDATE transactions
-        SET exchange_rate_id = $1
+        SET exchange_rate_id = $1,
+            updated_at = $5
         WHERE currency_code = $2
           AND user_id = $3
           AND date >= $4
-    `, [id, currencyCode, userId, dateStr]);
+          AND deleted_at IS NULL
+        RETURNING id
+    `, [id, currencyCode, userId, dateStr, timestamp]);
 
     await trackChange('exchange_rates', id, 'INSERT', exchangeRate);
+
+    // The repoint mutates each transaction locally; queue those changes too. Without
+    // this the new rate never reaches the server, so other devices keep the old rate
+    // and a later full resync silently reverts the local re-valuation — the balances
+    // that "change on their own a couple times a month".
+    for (const row of repointed.rows) {
+        await trackChange('transactions', row.id, 'UPDATE', {
+            id: row.id,
+            exchange_rate_id: id,
+            updated_at: timestamp,
+        });
+    }
+
     triggerBackgroundSync();
 
     return exchangeRate;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -324,6 +324,9 @@ export async function fetchTransactionsRange(startDate: string, endDate: string)
     return mergeTransactions(virtual, physical, movedOverrides.rows);
 }
 
+// startDate/endDate form a half-open range [startDate, endDate): endDate is the first
+// day AFTER the period. Both the physical query and the virtual generator use the same
+// exclusive bound so a charge on the period's last day is counted consistently.
 export async function fetchCreditTransactions(cardId: string, startDate: string, endDate: string): Promise<Transaction[]> {
     const db = await getDatabaseAsync();
     const userId = await getUserId();
@@ -340,7 +343,7 @@ export async function fetchCreditTransactions(cardId: string, startDate: string,
           AND t.deleted_at IS NULL
           AND t.credit_card_id = $2
           AND t.date >= $3
-          AND t.date <= $4
+          AND t.date < $4
         ORDER BY t.date ASC
     `, [userId, cardId, startDate, endDate]);
 
@@ -367,8 +370,8 @@ export async function fetchCreditTransactions(cardId: string, startDate: string,
           AND recurring_rule_id IS NOT NULL
           AND original_date IS NOT NULL
           AND original_date >= $3
-          AND original_date <= $4
-          AND (date < $3 OR date > $4)
+          AND original_date < $4
+          AND (date < $3 OR date >= $4)
     `, [userId, cardId, startDate, endDate]);
 
     const rules = await fetchRecurringRules();

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -10,7 +10,9 @@ import {
     getPeriodRange,
     getPeriodForDate,
     getCurrentPeriodAnchor,
-    getPeriodLabel
+    getPeriodLabel,
+    addMonthsClamped,
+    shouldDeriveCardEffectiveDate
 } from './dates';
 
 describe('Date Utilities', () => {
@@ -270,6 +272,57 @@ describe('Financial Period Utilities', () => {
             expect(getPeriodLabel('2026-07')).toBe('August 2026');
             // Dec 20–Jan 19: end month rolls into the next year
             expect(getPeriodLabel('2026-12')).toBe('January 2027');
+        });
+    });
+
+    describe('addMonthsClamped', () => {
+        it('clamps day-31 to the last valid day of the target month', () => {
+            expect(formatLocalDate(addMonthsClamped(parseLocalDate('2024-01-31'), 1))).toBe('2024-02-29'); // leap
+            expect(formatLocalDate(addMonthsClamped(parseLocalDate('2025-01-31'), 1))).toBe('2025-02-28');
+            expect(formatLocalDate(addMonthsClamped(parseLocalDate('2024-01-31'), 3))).toBe('2024-04-30');
+        });
+
+        it('is anchored to the original day, not accumulated (no drift)', () => {
+            // Reaching March directly keeps day 31; stepping through Feb must not drift.
+            expect(formatLocalDate(addMonthsClamped(parseLocalDate('2024-01-31'), 2))).toBe('2024-03-31');
+        });
+
+        it('handles year rollover and preserves days <= 28', () => {
+            expect(formatLocalDate(addMonthsClamped(parseLocalDate('2023-11-15'), 3))).toBe('2024-02-15');
+        });
+    });
+
+    describe('shouldDeriveCardEffectiveDate', () => {
+        it('derives for a brand-new transaction', () => {
+            expect(shouldDeriveCardEffectiveDate({
+                isNew: true, enteredDate: '2026-06-24', cardId: 'c1'
+            })).toBe(true);
+        });
+
+        it('does NOT re-derive when editing an unrelated field on the same card', () => {
+            // The core bug: editing a note must not shift the stored effective date.
+            expect(shouldDeriveCardEffectiveDate({
+                isNew: false, enteredDate: '2026-07-10', storedDate: '2026-07-10',
+                storedMethod: 'card', storedCardId: 'c1', cardId: 'c1'
+            })).toBe(false);
+        });
+
+        it('derives when the user changes the date', () => {
+            expect(shouldDeriveCardEffectiveDate({
+                isNew: false, enteredDate: '2026-08-01', storedDate: '2026-07-10',
+                storedMethod: 'card', storedCardId: 'c1', cardId: 'c1'
+            })).toBe(true);
+        });
+
+        it('derives when the card is (re)assigned or converted from cash', () => {
+            expect(shouldDeriveCardEffectiveDate({
+                isNew: false, enteredDate: '2026-07-10', storedDate: '2026-07-10',
+                storedMethod: 'card', storedCardId: 'c1', cardId: 'c2'
+            })).toBe(true);
+            expect(shouldDeriveCardEffectiveDate({
+                isNew: false, enteredDate: '2026-07-10', storedDate: '2026-07-10',
+                storedMethod: 'cash', storedCardId: null, cardId: 'c1'
+            })).toBe(true);
         });
     });
 });

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -215,6 +215,31 @@ export function calculateCreditCardEffectiveDate(
     return nextPaymentDate;
 }
 
+/**
+ * Decides whether a credit-card transaction's effective date should be (re)derived
+ * from the entered date via {@link calculateCreditCardEffectiveDate}.
+ *
+ * That function is NOT idempotent — applying it to an already-shifted stored date
+ * marches the transaction forward a month on every save (and compounds), because it
+ * keys off today's date. So on edit we only recompute when the user actually entered
+ * a new raw purchase date, or (re)assigned the card. Editing any other field (note,
+ * amount, category…) preserves the stored effective date.
+ */
+export function shouldDeriveCardEffectiveDate(params: {
+    isNew: boolean;
+    enteredDate: string;
+    storedDate?: string | null;
+    storedMethod?: string | null;
+    storedCardId?: string | null;
+    cardId: string;
+}): boolean {
+    const { isNew, enteredDate, storedDate, storedMethod, storedCardId, cardId } = params;
+    if (isNew) return true;
+    if (enteredDate !== storedDate) return true;
+    const wasSameCard = storedMethod === 'card' && (storedCardId || '') === cardId;
+    return !wasSameCard;
+}
+
 export function getPersistentMonth(): Date {
     const saved = localStorage.getItem('selected_month');
     if (saved) {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -32,6 +32,26 @@ export function getTodayLocalDate(): string {
     return formatLocalDate(new Date());
 }
 
+/**
+ * Adds `months` to a date, clamping the day-of-month to the last valid day of the
+ * target month.
+ *
+ * Unlike `Date.prototype.setMonth` — which rolls e.g. Jan 31 + 1 month over into
+ * early March, and drifts further on every subsequent step — this keeps a monthly
+ * occurrence anchored to its intended day: Jan 31 + 1 => Feb 28/29, + 2 => Mar 31.
+ * Because the result depends only on (anchor, months) and never on how many
+ * intermediate steps were taken, occurrence dates are stable and independent of the
+ * window you iterate over. Handles negative `months` too.
+ */
+export function addMonthsClamped(date: Date, months: number): Date {
+    const monthIndex = date.getMonth() + months;
+    const targetYear = date.getFullYear() + Math.floor(monthIndex / 12);
+    const targetMonth = ((monthIndex % 12) + 12) % 12;
+    const daysInTarget = new Date(targetYear, targetMonth + 1, 0).getDate();
+    const day = Math.min(date.getDate(), daysInTarget);
+    return new Date(targetYear, targetMonth, day);
+}
+
 // ============================================================================
 // Financial period (custom month start day)
 // ============================================================================

--- a/src/lib/offline/sync/pull.test.ts
+++ b/src/lib/offline/sync/pull.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Record when each server query runs so we can assert the watermark predates them.
+const selectTimes: number[] = [];
+const queryResult = { data: [] as unknown[], error: null };
+const builder = {
+    gte: vi.fn(() => builder),
+    then: (resolve: (v: typeof queryResult) => void) => resolve(queryResult),
+};
+const selectMock = vi.fn((_cols: string) => {
+    selectTimes.push(Date.now());
+    return builder;
+});
+const fromMock = vi.fn((_table: string) => ({ select: selectMock }));
+
+const setLastSyncMock = vi.fn((_ts: string) => Promise.resolve());
+
+vi.mock('../../supabase', () => ({ supabase: { from: (t: string) => fromMock(t) } }));
+vi.mock('../database', () => ({
+    getDatabaseAsync: () => Promise.resolve({ query: vi.fn(() => Promise.resolve({ rows: [] })) }),
+    getLastSyncTimestamp: () => Promise.resolve(null),
+    setLastSyncTimestamp: (ts: string) => setLastSyncMock(ts),
+}));
+vi.mock('./queue', () => ({ getPendingChanges: () => Promise.resolve([]) }));
+
+import { pullChanges } from './pull';
+
+describe('pullChanges watermark', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        selectTimes.length = 0;
+    });
+
+    it('stamps last-sync from a watermark captured BEFORE the queries run', async () => {
+        const result = await pullChanges();
+        expect(result.success).toBe(true);
+        expect(setLastSyncMock).toHaveBeenCalledTimes(1);
+        expect(selectTimes.length).toBeGreaterThan(0);
+
+        const stampedAt = new Date(setLastSyncMock.mock.calls[0][0]).getTime();
+        const firstQueryAt = Math.min(...selectTimes);
+        // A watermark captured before querying is <= the first query time. The old code
+        // captured it after the whole loop, so it would be > the first query time.
+        expect(stampedAt).toBeLessThanOrEqual(firstQueryAt);
+    });
+});

--- a/src/lib/offline/sync/pull.ts
+++ b/src/lib/offline/sync/pull.ts
@@ -24,6 +24,13 @@ export async function pullChanges(): Promise<PullResult> {
     };
 
     const lastSync = await getLastSyncTimestamp();
+    // Capture the watermark BEFORE issuing any query. The next pull filters on the
+    // server's updated_at >= this value, so it must be a lower bound on "when this pull
+    // observed the server". Stamping it AFTER the queries (as before) skipped any row
+    // written during the pull window: its updated_at landed between a table's query and
+    // the post-loop stamp, so it was in neither this result set nor the next pull's
+    // filter — a permanent silent divergence.
+    const watermark = new Date().toISOString();
     console.log(`[Sync Pull] Starting pull, last sync: ${lastSync || 'never'}`);
     const pendingChanges = await getPendingChanges();
     const pendingByTable = new Map<SyncTableName, Set<string>>(
@@ -49,9 +56,9 @@ export async function pullChanges(): Promise<PullResult> {
         }
     }
 
-    // Update last sync timestamp if successful
+    // Update last sync timestamp if successful (using the pre-query watermark).
     if (result.success) {
-        await setLastSyncTimestamp(new Date().toISOString());
+        await setLastSyncTimestamp(watermark);
     }
 
     console.log(`[Sync Pull] Complete: ${result.recordsProcessed} records from ${result.tablesUpdated} tables`);
@@ -212,6 +219,9 @@ export async function initialHydration(
     }
 
     console.log('[Sync] Starting initial hydration...');
+    // Capture the watermark before downloading so any row written during the (possibly
+    // long) hydration is picked up by the first incremental pull rather than skipped.
+    const watermark = new Date().toISOString();
     const db = await getDatabaseAsync();
 
     for (let i = 0; i < SYNC_TABLES.length; i++) {
@@ -231,7 +241,7 @@ export async function initialHydration(
         }
     }
 
-    await setLastSyncTimestamp(new Date().toISOString());
+    await setLastSyncTimestamp(watermark);
     console.log('[Sync] Initial hydration complete');
 }
 

--- a/src/lib/offline/sync/pull.ts
+++ b/src/lib/offline/sync/pull.ts
@@ -237,7 +237,8 @@ export async function initialHydration(
 
 async function hydrateTable(
     db: Awaited<ReturnType<typeof getDatabaseAsync>>,
-    table: SyncTableName
+    table: SyncTableName,
+    pendingRecordIds?: Set<string>
 ): Promise<void> {
     const { data, error } = await supabase
         .from(table)
@@ -247,7 +248,7 @@ async function hydrateTable(
     if (!data || data.length === 0) return;
 
     for (const record of data) {
-        await upsertLocalRecord(db, table, record);
+        await upsertLocalRecord(db, table, record, pendingRecordIds);
     }
 
     console.log(`[Sync] Hydrated ${table}: ${data.length} records`);
@@ -256,7 +257,8 @@ async function hydrateTable(
 async function hydrateTablePaginated(
     db: Awaited<ReturnType<typeof getDatabaseAsync>>,
     table: SyncTableName,
-    pageSize: number = 1000
+    pageSize: number = 1000,
+    pendingRecordIds?: Set<string>
 ): Promise<void> {
     let offset = 0;
     let hasMore = true;
@@ -281,7 +283,7 @@ async function hydrateTablePaginated(
 
 
         for (const record of data) {
-            await upsertLocalRecord(db, table, record);
+            await upsertLocalRecord(db, table, record, pendingRecordIds);
         }
 
         totalRecords += data.length;
@@ -336,15 +338,30 @@ export async function fullTableResync(table: SyncTableName): Promise<number> {
     // Ensure FK dependencies are populated before clearing and resyncing
     await ensureDependenciesPopulated(db, table);
 
-    // Clear local table data
-    await db.query(`DELETE FROM ${table}`);
-    console.log(`[Sync] Cleared local ${table} table`);
+    // Preserve rows that still have unsynced local changes: a blind DELETE +
+    // re-hydrate would revert a pending soft-delete (row comes back) or drop a
+    // locally-created row whose insert hasn't reached the server yet. Keep those
+    // rows and skip their server copies during re-hydrate so local stays authoritative
+    // until the pending change is pushed.
+    const pending = await getPendingChanges();
+    const pkColumn = getPrimaryKeyColumn(table);
+    const pendingIds = new Set(
+        pending.filter(c => c.table_name === table).map(c => c.record_id)
+    );
+
+    // Clear local table data (except rows with pending local changes)
+    if (pendingIds.size > 0) {
+        await db.query(`DELETE FROM ${table} WHERE NOT (${pkColumn} = ANY($1))`, [[...pendingIds]]);
+    } else {
+        await db.query(`DELETE FROM ${table}`);
+    }
+    console.log(`[Sync] Cleared local ${table} table (${pendingIds.size} pending rows preserved)`);
 
     // Re-hydrate from server
     if (table === 'transactions') {
-        await hydrateTablePaginated(db, table);
+        await hydrateTablePaginated(db, table, 1000, pendingIds);
     } else {
-        await hydrateTable(db, table);
+        await hydrateTable(db, table, pendingIds);
     }
 
     // Get new count

--- a/src/lib/offline/sync/push.test.ts
+++ b/src/lib/offline/sync/push.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PendingChange } from './queue';
 
-// --- Controllable supabase mock -------------------------------------------------
 type SbError = { code: string; message: string } | null;
+type SbResult = { data?: Array<{ id: string }>; error: SbError };
+
+// Terminal result for update/delete chains; mutated per test to simulate zero rows.
+let terminalResult: SbResult = { data: [{ id: 'srv-id' }], error: null };
+
+// --- Controllable, chainable supabase mock --------------------------------------
 const insertMock = vi.fn((_payload?: unknown): Promise<{ error: SbError }> => Promise.resolve({ error: null }));
-const eqInner = vi.fn((_col: string, _val: unknown) => Promise.resolve({ error: null }));
-const eqOuter = vi.fn((_col: string, _val: unknown) => ({ eq: eqInner }));
-const updateMock = vi.fn((_fields: Record<string, unknown>) => ({ eq: eqOuter }));
+const selectMock = vi.fn((_cols?: string) => Promise.resolve(terminalResult));
+const eqMock = vi.fn((_col: string, _val: unknown) => chainObj);
+// chainObj is awaitable (for the override update().eq().eq() path) and also exposes
+// .select() (for the update().eq().select() path used by pushUpdate/pushDelete).
+const chainObj = {
+    eq: eqMock,
+    select: selectMock,
+    then: (resolve: (v: SbResult) => void) => resolve(terminalResult),
+};
+const updateMock = vi.fn((_fields: Record<string, unknown>) => chainObj);
 const upsertMock = vi.fn();
 const fromMock = vi.fn((_table: string) => ({ insert: insertMock, update: updateMock, upsert: upsertMock }));
 
@@ -20,21 +32,13 @@ vi.mock('./queue', () => ({
 
 import { pushChangeImmediately } from './push';
 
-function overrideChange(): PendingChange {
+function change(op: PendingChange['operation'], payload: Record<string, unknown>): PendingChange {
     return {
         id: 1,
         table_name: 'transactions',
-        record_id: 'local-uuid',
-        operation: 'INSERT',
-        payload: JSON.stringify({
-            id: 'local-uuid',
-            user_id: 'u1',
-            recurring_rule_id: 'rule-1',
-            original_date: '2026-07-30',
-            date: '2026-07-30',
-            amount_cents: 1000,
-            created_at: '2026-07-30T00:00:00Z',
-        }),
+        record_id: String(payload.id ?? 'rec'),
+        operation: op,
+        payload: JSON.stringify(payload),
         created_at: '2026-07-30T00:00:00Z',
         synced_at: null,
         retry_count: 0,
@@ -42,12 +46,21 @@ function overrideChange(): PendingChange {
     };
 }
 
+const overridePayload = {
+    id: 'local-uuid', user_id: 'u1', recurring_rule_id: 'rule-1',
+    original_date: '2026-07-30', date: '2026-07-30', amount_cents: 1000,
+    created_at: '2026-07-30T00:00:00Z',
+};
+
 describe('pushInsert override conflict handling', () => {
-    beforeEach(() => vi.clearAllMocks());
+    beforeEach(() => {
+        vi.clearAllMocks();
+        terminalResult = { data: [{ id: 'srv-id' }], error: null };
+    });
 
     it('inserts a new override by id (no upsert that could rename the PK)', async () => {
         insertMock.mockResolvedValueOnce({ error: null });
-        const ok = await pushChangeImmediately(overrideChange());
+        const ok = await pushChangeImmediately(change('INSERT', overridePayload));
         expect(ok).toBe(true);
         expect(insertMock).toHaveBeenCalledTimes(1);
         expect(upsertMock).not.toHaveBeenCalled();
@@ -56,18 +69,41 @@ describe('pushInsert override conflict handling', () => {
 
     it('on unique conflict, updates by natural key WITHOUT touching id/created_at', async () => {
         insertMock.mockResolvedValueOnce({ error: { code: '23505', message: 'duplicate key' } });
-        const ok = await pushChangeImmediately(overrideChange());
+        const ok = await pushChangeImmediately(change('INSERT', overridePayload));
         expect(ok).toBe(true);
 
         expect(upsertMock).not.toHaveBeenCalled();
         expect(updateMock).toHaveBeenCalledTimes(1);
         const updatePayload = updateMock.mock.calls[0][0];
-        // The id must never be part of the update — that is the PK-rewrite bug.
         expect(updatePayload).not.toHaveProperty('id');
         expect(updatePayload).not.toHaveProperty('created_at');
         expect(updatePayload).toMatchObject({ amount_cents: 1000 });
-        // Targeted by the natural key, not by id.
-        expect(eqOuter).toHaveBeenCalledWith('recurring_rule_id', 'rule-1');
-        expect(eqInner).toHaveBeenCalledWith('original_date', '2026-07-30');
+        expect(eqMock).toHaveBeenCalledWith('recurring_rule_id', 'rule-1');
+        expect(eqMock).toHaveBeenCalledWith('original_date', '2026-07-30');
+    });
+});
+
+describe('pushUpdate / pushDelete zero-row handling', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        terminalResult = { data: [{ id: 'srv-id' }], error: null };
+    });
+
+    it('succeeds when the update matches a server row', async () => {
+        const ok = await pushChangeImmediately(change('UPDATE', { id: 't1', amount_cents: 5, updated_at: 'x' }));
+        expect(ok).toBe(true);
+        expect(selectMock).toHaveBeenCalled();
+    });
+
+    it('fails (retries) when the update matches NO server row', async () => {
+        terminalResult = { data: [], error: null };
+        const ok = await pushChangeImmediately(change('UPDATE', { id: 't1', amount_cents: 5, updated_at: 'x' }));
+        expect(ok).toBe(false);
+    });
+
+    it('fails (retries) when a delete matches NO server row — prevents resurrection', async () => {
+        terminalResult = { data: [], error: null };
+        const ok = await pushChangeImmediately(change('DELETE', { id: 't1', deleted_at: 'x' }));
+        expect(ok).toBe(false);
     });
 });

--- a/src/lib/offline/sync/push.test.ts
+++ b/src/lib/offline/sync/push.test.ts
@@ -6,23 +6,41 @@ type SbResult = { data?: Array<{ id: string }>; error: SbError };
 
 // Terminal result for update/delete chains; mutated per test to simulate zero rows.
 let terminalResult: SbResult = { data: [{ id: 'srv-id' }], error: null };
+// Result of the adopt lookup: which server id (if any) owns the occurrence.
+let serverSelectResult: { data: { id: string } | null; error: SbError } = { data: { id: 'srv-id' }, error: null };
 
 // --- Controllable, chainable supabase mock --------------------------------------
 const insertMock = vi.fn((_payload?: unknown): Promise<{ error: SbError }> => Promise.resolve({ error: null }));
+
+// update(...).eq(...).eq(...)  (natural-key update, awaited)
+// update(...).eq(...).select() (pushUpdate/pushDelete)
 const selectMock = vi.fn((_cols?: string) => Promise.resolve(terminalResult));
-const eqMock = vi.fn((_col: string, _val: unknown) => chainObj);
-// chainObj is awaitable (for the override update().eq().eq() path) and also exposes
-// .select() (for the update().eq().select() path used by pushUpdate/pushDelete).
-const chainObj = {
+const eqMock = vi.fn((_col: string, _val: unknown) => updateChain);
+const updateChain = {
     eq: eqMock,
     select: selectMock,
     then: (resolve: (v: SbResult) => void) => resolve(terminalResult),
 };
-const updateMock = vi.fn((_fields: Record<string, unknown>) => chainObj);
+const updateMock = vi.fn((_fields: Record<string, unknown>) => updateChain);
+
+// select('id').eq(...).eq(...).maybeSingle()  (adopt lookup)
+const maybeSingleMock = vi.fn(() => Promise.resolve(serverSelectResult));
+const selectEqMock = vi.fn((_col: string, _val: unknown) => selectChain);
+const selectChain = { eq: selectEqMock, maybeSingle: maybeSingleMock };
+const fromSelectMock = vi.fn((_cols: string) => selectChain);
+
 const upsertMock = vi.fn();
-const fromMock = vi.fn((_table: string) => ({ insert: insertMock, update: updateMock, upsert: upsertMock }));
+const fromMock = vi.fn((_table: string) => ({
+    insert: insertMock,
+    update: updateMock,
+    select: fromSelectMock,
+    upsert: upsertMock,
+}));
+
+const dbQueryMock = vi.fn((_sql: string, _params?: unknown[]) => Promise.resolve({ rows: [] }));
 
 vi.mock('../../supabase', () => ({ supabase: { from: (table: string) => fromMock(table) } }));
+vi.mock('../database', () => ({ getDatabaseAsync: () => Promise.resolve({ query: dbQueryMock }) }));
 vi.mock('./queue', () => ({
     markChangeAsSynced: vi.fn(() => Promise.resolve()),
     recordSyncError: vi.fn(() => Promise.resolve()),
@@ -56,6 +74,7 @@ describe('pushInsert override conflict handling', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         terminalResult = { data: [{ id: 'srv-id' }], error: null };
+        serverSelectResult = { data: { id: 'srv-id' }, error: null };
     });
 
     it('inserts a new override by id (no upsert that could rename the PK)', async () => {
@@ -65,6 +84,7 @@ describe('pushInsert override conflict handling', () => {
         expect(insertMock).toHaveBeenCalledTimes(1);
         expect(upsertMock).not.toHaveBeenCalled();
         expect(updateMock).not.toHaveBeenCalled();
+        expect(dbQueryMock).not.toHaveBeenCalled();
     });
 
     it('on unique conflict, updates by natural key WITHOUT touching id/created_at', async () => {
@@ -81,12 +101,38 @@ describe('pushInsert override conflict handling', () => {
         expect(eqMock).toHaveBeenCalledWith('recurring_rule_id', 'rule-1');
         expect(eqMock).toHaveBeenCalledWith('original_date', '2026-07-30');
     });
+
+    it('adopts the server id locally when it differs (repoints row + pending changes)', async () => {
+        insertMock.mockResolvedValueOnce({ error: { code: '23505', message: 'duplicate key' } });
+        serverSelectResult = { data: { id: 'srv-id' }, error: null };
+
+        const ok = await pushChangeImmediately(change('INSERT', overridePayload));
+        expect(ok).toBe(true);
+
+        const idUpdate = dbQueryMock.mock.calls.find(c => /UPDATE transactions SET id/.test(c[0]));
+        expect(idUpdate).toBeDefined();
+        expect(idUpdate![1]).toEqual(['srv-id', 'local-uuid']);
+
+        const pendingRemap = dbQueryMock.mock.calls.find(c => /_pending_changes SET record_id/.test(c[0]));
+        expect(pendingRemap).toBeDefined();
+        expect(pendingRemap![1]).toEqual(['srv-id', 'transactions', 'local-uuid']);
+    });
+
+    it('does not touch local ids when the server already holds our id', async () => {
+        insertMock.mockResolvedValueOnce({ error: { code: '23505', message: 'duplicate key' } });
+        serverSelectResult = { data: { id: 'local-uuid' }, error: null }; // same id -> nothing to adopt
+
+        const ok = await pushChangeImmediately(change('INSERT', overridePayload));
+        expect(ok).toBe(true);
+        expect(dbQueryMock).not.toHaveBeenCalled();
+    });
 });
 
 describe('pushUpdate / pushDelete zero-row handling', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         terminalResult = { data: [{ id: 'srv-id' }], error: null };
+        serverSelectResult = { data: { id: 'srv-id' }, error: null };
     });
 
     it('succeeds when the update matches a server row', async () => {

--- a/src/lib/offline/sync/push.test.ts
+++ b/src/lib/offline/sync/push.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PendingChange } from './queue';
+
+// --- Controllable supabase mock -------------------------------------------------
+type SbError = { code: string; message: string } | null;
+const insertMock = vi.fn((_payload?: unknown): Promise<{ error: SbError }> => Promise.resolve({ error: null }));
+const eqInner = vi.fn((_col: string, _val: unknown) => Promise.resolve({ error: null }));
+const eqOuter = vi.fn((_col: string, _val: unknown) => ({ eq: eqInner }));
+const updateMock = vi.fn((_fields: Record<string, unknown>) => ({ eq: eqOuter }));
+const upsertMock = vi.fn();
+const fromMock = vi.fn((_table: string) => ({ insert: insertMock, update: updateMock, upsert: upsertMock }));
+
+vi.mock('../../supabase', () => ({ supabase: { from: (table: string) => fromMock(table) } }));
+vi.mock('./queue', () => ({
+    markChangeAsSynced: vi.fn(() => Promise.resolve()),
+    recordSyncError: vi.fn(() => Promise.resolve()),
+    getPendingChanges: vi.fn(() => Promise.resolve([])),
+    clearSyncedChanges: vi.fn(() => Promise.resolve()),
+}));
+
+import { pushChangeImmediately } from './push';
+
+function overrideChange(): PendingChange {
+    return {
+        id: 1,
+        table_name: 'transactions',
+        record_id: 'local-uuid',
+        operation: 'INSERT',
+        payload: JSON.stringify({
+            id: 'local-uuid',
+            user_id: 'u1',
+            recurring_rule_id: 'rule-1',
+            original_date: '2026-07-30',
+            date: '2026-07-30',
+            amount_cents: 1000,
+            created_at: '2026-07-30T00:00:00Z',
+        }),
+        created_at: '2026-07-30T00:00:00Z',
+        synced_at: null,
+        retry_count: 0,
+        error: null,
+    };
+}
+
+describe('pushInsert override conflict handling', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('inserts a new override by id (no upsert that could rename the PK)', async () => {
+        insertMock.mockResolvedValueOnce({ error: null });
+        const ok = await pushChangeImmediately(overrideChange());
+        expect(ok).toBe(true);
+        expect(insertMock).toHaveBeenCalledTimes(1);
+        expect(upsertMock).not.toHaveBeenCalled();
+        expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('on unique conflict, updates by natural key WITHOUT touching id/created_at', async () => {
+        insertMock.mockResolvedValueOnce({ error: { code: '23505', message: 'duplicate key' } });
+        const ok = await pushChangeImmediately(overrideChange());
+        expect(ok).toBe(true);
+
+        expect(upsertMock).not.toHaveBeenCalled();
+        expect(updateMock).toHaveBeenCalledTimes(1);
+        const updatePayload = updateMock.mock.calls[0][0];
+        // The id must never be part of the update — that is the PK-rewrite bug.
+        expect(updatePayload).not.toHaveProperty('id');
+        expect(updatePayload).not.toHaveProperty('created_at');
+        expect(updatePayload).toMatchObject({ amount_cents: 1000 });
+        // Targeted by the natural key, not by id.
+        expect(eqOuter).toHaveBeenCalledWith('recurring_rule_id', 'rule-1');
+        expect(eqInner).toHaveBeenCalledWith('original_date', '2026-07-30');
+    });
+});

--- a/src/lib/offline/sync/push.ts
+++ b/src/lib/offline/sync/push.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../../supabase';
+import { getDatabaseAsync } from '../database';
 import { SYNC_TABLES, type SyncTableName } from '../schema';
 import {
     getPendingChanges,
@@ -129,6 +130,18 @@ async function pushInsert(
             .eq('original_date', payload.original_date);
 
         if (updateError) throw new Error(updateError.message);
+
+        // If another device created this occurrence first, the server row keeps ITS id,
+        // not ours. Converge the local row (and any queued changes) onto the server id,
+        // otherwise our later edits/deletes would be keyed by our stale local id, match
+        // zero server rows, and retry forever — and pull can't repair it because the
+        // local table already holds this natural key under a different id.
+        await adoptServerOverrideId(
+            table,
+            String(payload.id),
+            String(payload.recurring_rule_id),
+            String(payload.original_date)
+        );
         return;
     }
 
@@ -143,6 +156,43 @@ async function pushInsert(
             return;
         }
         throw new Error(error.message);
+    }
+}
+
+/**
+ * After a natural-key override conflict, point the local row and any still-pending
+ * changes at the id the server actually holds, so later local edits/deletes (matched by
+ * id) target the right row. Best-effort: the server content is already correct, so a
+ * failure here must not fail the push (it would just leave the id divergence for a
+ * future pull/push to resolve).
+ */
+async function adoptServerOverrideId(
+    table: SyncTableName,
+    localId: string,
+    recurringRuleId: string,
+    originalDate: string
+): Promise<void> {
+    try {
+        const { data, error } = await supabase
+            .from(table)
+            .select('id')
+            .eq('recurring_rule_id', recurringRuleId)
+            .eq('original_date', originalDate)
+            .maybeSingle();
+
+        const serverId = data?.id as string | undefined;
+        if (error || !serverId || serverId === localId) return;
+
+        const db = await getDatabaseAsync();
+        await db.query(`UPDATE ${table} SET id = $1 WHERE id = $2`, [serverId, localId]);
+        await db.query(
+            `UPDATE _pending_changes SET record_id = $1
+             WHERE table_name = $2 AND record_id = $3 AND synced_at IS NULL`,
+            [serverId, table, localId]
+        );
+        console.log(`[Sync Push] Adopted server id for ${table} override: ${localId} -> ${serverId}`);
+    } catch (err) {
+        console.warn('[Sync Push] Failed to adopt server override id (will retry later):', err);
     }
 }
 

--- a/src/lib/offline/sync/push.ts
+++ b/src/lib/offline/sync/push.ts
@@ -154,13 +154,20 @@ async function pushUpdate(
     // Remove system fields that shouldn't be updated
     const { id, user_id, created_at, ...updatePayload } = payload;
 
-    const { error } = await supabase
+    const { data, error } = await supabase
         .from(table)
         .update(updatePayload)
-        .eq('id', recordId);
+        .eq('id', recordId)
+        .select('id');
 
     if (error) {
         throw new Error(error.message);
+    }
+    // A Supabase update that matches no row returns success with an empty set. That
+    // happens when the target row's INSERT hasn't reached the server yet. Treat it as
+    // a retryable failure instead of marking it synced, otherwise the update is lost.
+    if (!data || data.length === 0) {
+        throw new Error(`No server row matched update for ${table}/${recordId} (insert not yet synced?)`);
     }
 }
 
@@ -170,13 +177,20 @@ async function pushDelete(
     payload: Record<string, unknown>
 ): Promise<void> {
     // Soft delete - update deleted_at timestamp
-    const { error } = await supabase
+    const { data, error } = await supabase
         .from(table)
         .update({ deleted_at: payload.deleted_at })
-        .eq('id', recordId);
+        .eq('id', recordId)
+        .select('id');
 
     if (error) {
         throw new Error(error.message);
+    }
+    // Same guard as pushUpdate: a delete matching zero rows means the row's INSERT
+    // hasn't been pushed yet. Retrying (rather than succeeding) prevents the classic
+    // resurrection where the delete is dropped and the later insert brings the row back.
+    if (!data || data.length === 0) {
+        throw new Error(`No server row matched delete for ${table}/${recordId} (insert not yet synced?)`);
     }
 }
 

--- a/src/lib/offline/sync/push.ts
+++ b/src/lib/offline/sync/push.ts
@@ -102,24 +102,33 @@ async function pushInsert(
     // Remove user_id - Supabase will set it via RLS default
     const { user_id, ...insertPayload } = payload;
 
-    // For transaction overrides, use upsert on the (recurring_rule_id, original_date) constraint
-    // This handles the case where user edits the same occurrence multiple times
+    // For transaction overrides, an occurrence is uniquely identified by
+    // (recurring_rule_id, original_date). We must NOT use supabase upsert on that
+    // constraint: on conflict it runs DO UPDATE SET id = EXCLUDED.id, renaming the
+    // existing server row's primary key to this device's freshly-minted UUID. That
+    // orphans the other device's copy of the same occurrence, which then re-pulls
+    // under a new id and either duplicates it or (with the local UNIQUE constraint)
+    // silently disappears. Instead: try a plain INSERT, and on any unique-constraint
+    // conflict UPDATE the existing row BY NATURAL KEY, leaving its id untouched.
     if (table === 'transactions' && payload.recurring_rule_id && payload.original_date) {
         const { error } = await supabase
             .from(table)
-            .upsert(insertPayload, {
-                onConflict: 'recurring_rule_id,original_date',
-                ignoreDuplicates: false
-            });
+            .insert(insertPayload);
 
-        if (error) {
-            // If upsert fails due to primary key conflict, the record already exists with same ID
-            if (error.code === '23505') {
-                console.log(`[Sync Push] Record already exists, treating as success: ${table}/${payload.id}`);
-                return;
-            }
-            throw new Error(error.message);
-        }
+        if (!error) return;
+        if (error.code !== '23505') throw new Error(error.message);
+
+        // An override for this occurrence already exists on the server (same id
+        // re-synced, or a different id created on another device). Update its content
+        // by natural key, preserving whatever id the server already holds.
+        const { id: _omitId, created_at: _omitCreatedAt, ...updateFields } = insertPayload;
+        const { error: updateError } = await supabase
+            .from(table)
+            .update(updateFields)
+            .eq('recurring_rule_id', payload.recurring_rule_id)
+            .eq('original_date', payload.original_date);
+
+        if (updateError) throw new Error(updateError.message);
         return;
     }
 

--- a/src/lib/offline/sync/queue.test.ts
+++ b/src/lib/offline/sync/queue.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const queryMock = vi.fn((_sql: string) => Promise.resolve({ rows: [] }));
+vi.mock('../database', () => ({ getDatabaseAsync: () => Promise.resolve({ query: queryMock }) }));
+
+import { getPendingChanges } from './queue';
+
+describe('getPendingChanges ordering', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('orders by created_at then the monotonic id (FIFO tiebreaker)', async () => {
+        await getPendingChanges();
+        const sql = queryMock.mock.calls[0][0].replace(/\s+/g, ' ');
+        expect(sql).toContain('ORDER BY created_at ASC, id ASC');
+    });
+});

--- a/src/lib/offline/sync/queue.ts
+++ b/src/lib/offline/sync/queue.ts
@@ -51,10 +51,14 @@ export async function trackChange(
 
 export async function getPendingChanges(): Promise<PendingChange[]> {
     const db = await getDatabaseAsync();
+    // Order by the monotonic SERIAL id as a tiebreaker: created_at has only
+    // millisecond precision, so two changes to the same record in the same ms would
+    // otherwise be returned in an arbitrary order and an UPDATE could be pushed before
+    // its INSERT.
     const result = await db.query<PendingChange>(`
         SELECT * FROM _pending_changes
         WHERE synced_at IS NULL
-        ORDER BY created_at ASC
+        ORDER BY created_at ASC, id ASC
     `);
     return result.rows;
 }

--- a/src/lib/offline/sync/reconcile.test.ts
+++ b/src/lib/offline/sync/reconcile.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const rpcMock = vi.fn();
+const queryMock = vi.fn((sql: string) => {
+    // Local count = 4 for transactions (server says 5 -> mismatch), 0 elsewhere.
+    const table = /FROM (\w+)/.exec(sql)?.[1];
+    return Promise.resolve({ rows: [{ count: table === 'transactions' ? 4 : 0 }] });
+});
+const getPendingChangesMock = vi.fn(() => Promise.resolve<Array<{ table_name: string; record_id: string }>>([]));
+
+vi.mock('../../supabase', () => ({ supabase: { rpc: (...a: unknown[]) => rpcMock(...a) } }));
+vi.mock('../database', () => ({ getDatabaseAsync: () => Promise.resolve({ query: queryMock }) }));
+vi.mock('./queue', () => ({ getPendingChanges: () => getPendingChangesMock() }));
+
+import { checkReconciliation } from './reconcile';
+
+describe('checkReconciliation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        rpcMock.mockResolvedValue({
+            data: [
+                { table_name: 'transactions', record_count: 5 },
+                { table_name: 'recurring_rules', record_count: 0 },
+                { table_name: 'credit_cards', record_count: 0 },
+                { table_name: 'exchange_rates', record_count: 0 },
+                { table_name: 'parameters', record_count: 0 },
+            ],
+            error: null,
+        });
+        getPendingChangesMock.mockResolvedValue([]);
+    });
+
+    it('flags a table whose count differs and has no pending changes', async () => {
+        const result = await checkReconciliation();
+        expect(result.mismatches).toContain('transactions');
+    });
+
+    it('does NOT flag a table that has unsynced pending changes (avoids destructive resync)', async () => {
+        getPendingChangesMock.mockResolvedValue([{ table_name: 'transactions', record_id: 'tx-1' }]);
+        const result = await checkReconciliation();
+        expect(result.mismatches).not.toContain('transactions');
+    });
+});

--- a/src/lib/offline/sync/reconcile.ts
+++ b/src/lib/offline/sync/reconcile.ts
@@ -1,6 +1,7 @@
 import { supabase } from '../../supabase';
 import { getDatabaseAsync } from '../database';
 import { SYNC_TABLES, tableHasSoftDelete, type SyncTableName } from '../schema';
+import { getPendingChanges } from './queue';
 
 export interface ReconcileResult {
     checked: boolean;
@@ -32,11 +33,23 @@ export async function checkReconciliation(): Promise<ReconcileResult> {
             (serverData as SyncCountRow[]).map(r => [r.table_name, Number(r.record_count)])
         );
 
+        // Tables with unsynced local changes will legitimately differ in count from the
+        // server (a not-yet-pushed insert/delete). Flagging those as mismatches triggers
+        // a destructive full resync that reverts the pending local change, so skip them —
+        // the normal push will reconcile the counts.
+        const pending = await getPendingChanges();
+        const tablesWithPending = new Set(pending.map(c => c.table_name));
+
         // Get local counts
         const db = await getDatabaseAsync();
         for (const table of SYNC_TABLES) {
             // Skip currencies - reference data, not user-specific
             if (table === 'currencies') continue;
+
+            if (tablesWithPending.has(table)) {
+                console.log(`[Reconcile] ${table} skipped: has pending local changes`);
+                continue;
+            }
 
             const whereClause = tableHasSoftDelete(table) ? 'WHERE deleted_at IS NULL' : '';
             const localResult = await db.query<{ count: number }>(

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -1,22 +1,27 @@
 import type { ScheduleType } from '../types';
-import { parseLocalDate, formatLocalDate } from './dates';
+import { parseLocalDate, formatLocalDate, addMonthsClamped } from './dates';
 
 /**
  * Calculates the end date based on a start date, number of occurrences, and frequency.
+ *
+ * The end date is the date of the last (count-th) occurrence. Monthly schedules use
+ * `addMonthsClamped` so the result is anchored to the start day-of-month and does not
+ * drift for day 29–31 rules — consistent with `generateOccurrences`.
  */
 export function calculateEndDate(startDate: string, count: number, type: ScheduleType, n: number = 1): string {
-    const date = parseLocalDate(startDate);
+    const start = parseLocalDate(startDate);
+    // The first occurrence is the start date itself, so the last is at index count - 1.
+    const steps = Math.max(0, count - 1);
 
-    // The first occurrence is the start date itself, so we advance count - 1 times
-    for (let i = 1; i < count; i++) {
-        if (type === 'monthly_day') {
-            date.setMonth(date.getMonth() + 1);
-        } else if (type === 'every_n_days') {
-            date.setDate(date.getDate() + n);
-        } else if (type === 'every_n_months') {
-            date.setMonth(date.getMonth() + n);
-        }
+    let result: Date;
+    if (type === 'monthly_day') {
+        result = addMonthsClamped(start, steps);
+    } else if (type === 'every_n_months') {
+        result = addMonthsClamped(start, steps * n);
+    } else {
+        result = new Date(start);
+        result.setDate(result.getDate() + steps * n);
     }
 
-    return formatLocalDate(date);
+    return formatLocalDate(result);
 }

--- a/src/lib/recurringUtils.test.ts
+++ b/src/lib/recurringUtils.test.ts
@@ -59,6 +59,40 @@ describe('recurringUtils', () => {
             expect(occurrences).toHaveLength(3);
             expect(occurrences.map(o => o.date)).toEqual(['2024-01-01', '2024-04-01', '2024-07-01']);
         });
+
+        // Regression: monthly rules on day 29–31 must clamp to the last valid day of
+        // each month rather than drifting via Date.setMonth day-rollover.
+        it('clamps day-31 monthly rules to the last valid day of each month', () => {
+            const rule: RecurringRule = {
+                ...baseRule,
+                start_date: '2024-01-31',
+                schedule_type: 'monthly_day',
+                schedule_config: {}
+            };
+            const occurrences = generateOccurrences(rule, '2024-01-01', '2024-06-01');
+            // Feb clamps to 29 (2024 leap), Apr clamps to 30, others keep 31.
+            expect(occurrences.map(o => o.date)).toEqual([
+                '2024-01-31', '2024-02-29', '2024-03-31', '2024-04-30', '2024-05-31'
+            ]);
+        });
+
+        // Regression: the SAME occurrence must have the SAME date whether reached via a
+        // narrow single-month window or a wide multi-month window. A window-dependent
+        // date breaks override de-duplication and double-counts the occurrence.
+        it('produces window-independent dates for day-30 monthly rules', () => {
+            const rule: RecurringRule = {
+                ...baseRule,
+                start_date: '2026-01-30',
+                schedule_type: 'monthly_day',
+                schedule_config: {}
+            };
+            const wide = generateOccurrences(rule, '2026-01-01', '2027-01-01');
+            const julyFromWide = wide.find(o => o.date.startsWith('2026-07'))?.date;
+            const narrowJuly = generateOccurrences(rule, '2026-07-01', '2026-08-01');
+            expect(narrowJuly).toHaveLength(1);
+            expect(narrowJuly[0].date).toBe('2026-07-30');
+            expect(julyFromWide).toBe('2026-07-30');
+        });
     });
 
     describe('mergeTransactions', () => {

--- a/src/lib/recurringUtils.ts
+++ b/src/lib/recurringUtils.ts
@@ -1,9 +1,19 @@
 import type { RecurringRule, Transaction } from '../types';
-import { formatLocalDate, parseLocalDate } from './dates';
+import { formatLocalDate, parseLocalDate, addMonthsClamped } from './dates';
 import { pickRateForDate } from './currency';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 /**
  * Generates virtual occurrences for a recurring rule within a date range.
+ *
+ * Each occurrence's date is a pure function of the rule's start date and the
+ * occurrence index, so the same logical occurrence always yields the same date
+ * regardless of the window queried. This is critical: physical overrides are
+ * matched to virtuals by `original_date`, so a window-dependent date would let a
+ * virtual escape its override and get counted twice (see recurringUtils tests).
+ * Monthly schedules clamp to the last valid day (via `addMonthsClamped`) instead
+ * of drifting through `Date.setMonth` day-rollover.
  */
 export function generateOccurrences(
     rule: RecurringRule,
@@ -14,44 +24,45 @@ export function generateOccurrences(
     const occurrences: Transaction[] = [];
     if (!rule.active) return occurrences;
 
+    const scheduleType = rule.schedule_type;
+    if (scheduleType !== 'monthly_day' && scheduleType !== 'every_n_months' && scheduleType !== 'every_n_days') {
+        return occurrences;
+    }
+
     const startDate = parseLocalDate(rule.start_date);
     const endDate = rule.end_date ? parseLocalDate(rule.end_date) : null;
     const rangeStart = parseLocalDate(start);
     const rangeEnd = parseLocalDate(end);
+    const exceptionDates = new Set(rule.exception_dates || []);
+    const n = Math.max(1, Number(rule.schedule_config.n || 1));
 
-    let nextDate = new Date(startDate);
+    // Occurrence date as a pure function of the integer index — window-independent.
+    const dateForIndex = (index: number): Date => {
+        if (scheduleType === 'monthly_day') return addMonthsClamped(startDate, index);
+        if (scheduleType === 'every_n_months') return addMonthsClamped(startDate, index * n);
+        const d = new Date(startDate);
+        d.setDate(d.getDate() + index * n);
+        return d;
+    };
 
-    // Skip ahead as much as possible if startDate is far behind rangeStart
-    if (nextDate < rangeStart) {
-        if (rule.schedule_type === 'monthly_day') {
-            const monthsDiff = (rangeStart.getFullYear() - nextDate.getFullYear()) * 12 + (rangeStart.getMonth() - nextDate.getMonth());
-            if (monthsDiff > 1) {
-                nextDate.setMonth(nextDate.getMonth() + monthsDiff - 1);
-            }
-        } else if (rule.schedule_type === 'every_n_months') {
-            const n = Math.max(1, Number(rule.schedule_config.n || 1));
-            const totalMonthsDiff = (rangeStart.getFullYear() - nextDate.getFullYear()) * 12 + (rangeStart.getMonth() - nextDate.getMonth());
-            if (totalMonthsDiff > n) {
-                const jumps = Math.floor(totalMonthsDiff / n);
-                nextDate.setMonth(nextDate.getMonth() + (jumps - 1) * n);
-            }
-        } else if (rule.schedule_type === 'every_n_days') {
-            const n = Math.max(1, Number(rule.schedule_config.n || 1));
-            const diffTime = rangeStart.getTime() - nextDate.getTime();
-            const daysDiff = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-            if (daysDiff > n) {
-                const jumps = Math.floor(daysDiff / n);
-                nextDate.setDate(nextDate.getDate() + (jumps - 1) * n);
-            }
+    // Jump the index close to rangeStart without changing any resulting date.
+    // Deliberately undershoots by one step so we never skip a boundary occurrence.
+    let index = 0;
+    if (startDate < rangeStart) {
+        if (scheduleType === 'every_n_days') {
+            const daysDiff = Math.floor((rangeStart.getTime() - startDate.getTime()) / MS_PER_DAY);
+            index = Math.max(0, Math.floor(daysDiff / n) - 1);
+        } else {
+            const stepMonths = scheduleType === 'every_n_months' ? n : 1;
+            const monthsDiff = (rangeStart.getFullYear() - startDate.getFullYear()) * 12 + (rangeStart.getMonth() - startDate.getMonth());
+            index = Math.max(0, Math.floor(monthsDiff / stepMonths) - 1);
         }
     }
-
-    const exceptionDates = new Set(rule.exception_dates || []);
 
     // A safety limit to prevent infinite loops or excessive memory usage
     let count = 0;
     while (count < 1000) {
-        const dateStr = formatLocalDate(nextDate);
+        const nextDate = dateForIndex(index);
 
         // If we past the end range, we can stop (exclusive)
         if (nextDate >= rangeEnd) break;
@@ -59,42 +70,34 @@ export function generateOccurrences(
         // If we have an end date and we past it, we can stop
         if (endDate && nextDate > endDate) break;
 
-        if (nextDate >= rangeStart && !exceptionDates.has(dateStr)) {
-            // Best-effort: use the rate that was effective for this occurrence's month.
-            const ruleRate = pickRateForDate(rates, rule.currency_code, dateStr)?.rate ?? null;
-            occurrences.push({
-                id: `virtual-${rule.id}-${dateStr}`,
-                user_id: rule.user_id,
-                date: dateStr,
-                original_date: dateStr,
-                direction: rule.direction,
-                amount_cents: rule.amount_cents,
-                currency_code: rule.currency_code,
-                category: rule.category,
-                tag: rule.tag,
-                payment_method: rule.payment_method,
-                credit_card_id: rule.credit_card_id,
-                recurring_rule_id: rule.id,
-                to_be_balanced: false,
-                note: rule.note,
-                exchange_rate: ruleRate ? { rate: ruleRate } : null,
-                created_at: rule.created_at,
-                updated_at: rule.created_at,
-            });
+        if (nextDate >= rangeStart) {
+            const dateStr = formatLocalDate(nextDate);
+            if (!exceptionDates.has(dateStr)) {
+                // Best-effort: use the rate that was effective for this occurrence's month.
+                const ruleRate = pickRateForDate(rates, rule.currency_code, dateStr)?.rate ?? null;
+                occurrences.push({
+                    id: `virtual-${rule.id}-${dateStr}`,
+                    user_id: rule.user_id,
+                    date: dateStr,
+                    original_date: dateStr,
+                    direction: rule.direction,
+                    amount_cents: rule.amount_cents,
+                    currency_code: rule.currency_code,
+                    category: rule.category,
+                    tag: rule.tag,
+                    payment_method: rule.payment_method,
+                    credit_card_id: rule.credit_card_id,
+                    recurring_rule_id: rule.id,
+                    to_be_balanced: false,
+                    note: rule.note,
+                    exchange_rate: ruleRate ? { rate: ruleRate } : null,
+                    created_at: rule.created_at,
+                    updated_at: rule.created_at,
+                });
+            }
         }
 
-        // Advance nextDate based on schedule type
-        const n = Math.max(1, Number(rule.schedule_config.n || 1));
-        if (rule.schedule_type === 'monthly_day') {
-            nextDate.setMonth(nextDate.getMonth() + 1);
-        } else if (rule.schedule_type === 'every_n_days') {
-            nextDate.setDate(nextDate.getDate() + n);
-        } else if (rule.schedule_type === 'every_n_months') {
-            nextDate.setMonth(nextDate.getMonth() + n);
-        } else {
-            break;
-        }
-
+        index++;
         count++;
     }
 

--- a/src/pages/CreditReport.tsx
+++ b/src/pages/CreditReport.tsx
@@ -65,14 +65,12 @@ export function CreditReport() {
         if (!selectedCardId) return;
         setIsLoading(true);
         try {
-            // fetchCreditTransactions is inclusive on both ends, so convert the
-            // period's exclusive end into the last day of the period.
+            // fetchCreditTransactions takes a half-open range [start, end); pass the
+            // period's exclusive end directly so physical and recurring charges on the
+            // period's last day are included consistently.
             const { start: startStr, end: endExclusive } = getPeriodRange(formatLocalMonth(currentMonth));
-            const endDate = parseLocalDate(endExclusive);
-            endDate.setDate(endDate.getDate() - 1);
-            const endStr = formatLocalDate(endDate);
 
-            const txs = await fetchCreditTransactions(selectedCardId, startStr, endStr);
+            const txs = await fetchCreditTransactions(selectedCardId, startStr, endExclusive);
             setTransactions(txs);
         } catch (err) {
             console.error(err);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -425,8 +425,13 @@ function RatesSettings() {
     const handleSave = async (code: string) => {
         const val = inputs[code];
         if (!val) return;
+        const parsed = parseFloat(val);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+            alert("Please enter a rate greater than 0.");
+            return;
+        }
         try {
-            await insertExchangeRate(code, parseFloat(val));
+            await insertExchangeRate(code, parsed);
             alert(`Rate for ${code} updated! Transactions from this month onwards will now use this rate.`);
             load();
         } catch (err) {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,10 @@
 This directory contains Terraform configuration for deploying AWS infrastructure for Piggy Finance, including:
 
 - **Database Backup Lambda**: Weekly backups to S3 with 30-day retention
-- **Recurring Transaction Generator Lambda**: Monthly generation of recurring transactions
+
+> Note: recurring transactions are generated client-side ("virtual" occurrences in
+> `src/lib/recurringUtils.ts`); there is no longer a recurring-generator Lambda or an
+> `ensure_recurring_generated` RPC.
 
 ## Prerequisites
 
@@ -19,11 +22,6 @@ This directory contains Terraform configuration for deploying AWS infrastructure
 - **Retention**: 30 days (managed by S3 lifecycle policy + lambda cleanup)
 - **Runtime**: Python 3.11
 
-### Recurring Generator Lambda
-- **Trigger**: Monthly (1st day of month at 2 AM UTC)
-- **Function**: Calls `ensure_recurring_generated` RPC with 24-month horizon
-- **Runtime**: Python 3.11
-
 ## Deployment via GitHub Actions
 
 The infrastructure is automatically deployed when changes are pushed to the `main` branch:
@@ -35,7 +33,7 @@ The infrastructure is automatically deployed when changes are pushed to the `mai
 
 When updating lambda code:
 
-1. Modify files in `lambdas/backup/` or `lambdas/recurring_generator/`
+1. Modify files in `lambdas/backup/`
 2. Push to `main` branch
 3. GitHub Actions will automatically rebuild and deploy
 
@@ -49,12 +47,6 @@ aws lambda invoke \
   --function-name piggy_db_backup \
   --region us-east-1 \
   response.json
-
-# Test recurring generator lambda
-aws lambda invoke \
-  --function-name piggy_recurring_generator \
-  --region us-east-1 \
-  response.json
 ```
 
 ## Troubleshooting
@@ -64,7 +56,6 @@ aws lambda invoke \
 Check CloudWatch Logs:
 ```bash
 aws logs tail /aws/lambda/piggy_db_backup --follow
-aws logs tail /aws/lambda/piggy_recurring_generator --follow
 ```
 
 ### State Lock Issues

--- a/terraform/response.json
+++ b/terraform/response.json
@@ -1,1 +1,0 @@
-{"statusCode": 200, "body": "Successfully generated recurring transactions until 2027-12-19"}


### PR DESCRIPTION
## Why

Users reported unexpected **diffs** — monthly totals/balances that change on their own and need manual correction a couple times a month, plus recurring items that occasionally duplicate or disappear across devices. This branch fixes the root causes found in a focused bug hunt, re-verified against the just-merged custom-month-start-day changes.

Each item is its **own commit** (12 total). All fixes are covered by tests: **120 tests pass**, `npm run build` is green.

## Primary drift (deterministic, single-device — the "diffs" he couldn't pin)

1. **Window-dependent recurring dates** (`5c7ea1e`) — monthly rules on day 29–31 (salary/rent) generated *different dates for the same occurrence* depending on the view (`setMonth` drift + skip-ahead re-anchoring), so overrides stopped hiding their virtual → a full occurrence **counted twice** and pages disagreed. Now occurrence dates are a pure function of `(start_date, index)` with last-day clamping.
2. **Credit-card date drift on every edit** (`23a1e57`) — editing any field of a card transaction re-ran the effective-date calc from the already-shifted date and marched it one month forward (compounding) once the payment date passed. Now the effective date is only derived from a genuinely new/changed entry.
3. **Exchange-rate repoint never synced** (`2e21a6c`) — the repoint mutated `exchange_rate_id` locally with no `trackChange`, so balances reverted on the next full resync and diverged across devices. Now every repointed row is queued for sync.

## Secondary (the recurring dup/disappear + device desync)

4. **Override sync renamed rows' primary keys** across devices (`6f4baa7`) → dup/disappearance. Now updates by natural key without touching `id`.
5. **Count-only reconciliation reverted unsynced local state** (`ea98d88`) — skip tables with pending changes; `fullTableResync` preserves locally-pending rows.
6. **Resurrected deletes + non-deterministic queue order** (`873c425`) — zero-row updates/deletes now retry instead of silently succeeding; queue has a FIFO tiebreaker.
7. **Incremental-sync watermark captured after the queries** (`95b02d7`) → mid-pull writes were permanently missed. Now captured before querying.

## Correctness & cleanup

8. **Credit Report dropped last-day-of-period recurring charges** (`a4b0eff`) — `fetchCreditTransactions` is now half-open like the other fetchers.
9. **Annual-report rounding drift** (`b1f772c`) — accumulate full precision, round once (matches the summary cards / `computeMonthBalance`).
10. **Zero/invalid exchange rates rejected; tax totals count expenses only** (`dbffc3a`).
11. **Removed dead untracked `cleanupFutureRecurring`** (`3d97014`) — latent sync-divergence footgun.
12. **Removed stale `ensure_recurring_generated` / recurring-generator docs** (`bf6c74e`) — the job is retired; recurring is client-side virtual.

## Notes / follow-ups (not in this PR)

- **Existing overrides on day 29–31 rules**: fix #1 makes dates canonical; a previously-edited occurrence whose stored `original_date` used the old drifted value may show a transient double until re-saved. Rare (day-31 rules with existing overrides) and already broken today.
- **Server-side `repoint_exchange_rate` RPC** stays unused; the client-side durable repoint (#3) supersedes it.
- **Recurring credit-card charges** still use a different attribution path than one-off card charges (`RecurringRules.tsx`); noted for a future pass.
- **Late-night month-end FX entries** can still land in the wrong month bucket (UTC `created_at` vs local period) — minor, left as-is to avoid reshuffling existing rate attribution.
- Please confirm the retired `piggy_recurring_generator` Lambda / `ensure_recurring_generated` RPC are actually gone from the live AWS/Supabase (docs updated in #12; infra couldn't be verified from here).

## Testing

- 120 unit tests pass (new regressions for each fix: window-independence, card-edit idempotency, repoint tracking, override PK preservation, reconcile pending-skip, push zero-row/ordering, pull watermark, round-once, rate validation).
- `npm run build` (tsc + vite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)