### PR TITLE
Stringify exception_dates when pulling recurring rules

### DIFF
--- a/src/lib/offline/sync/pull.ts
+++ b/src/lib/offline/sync/pull.ts
@@ -192,8 +192,10 @@ function prepareRecordForLocal(
     const prepared: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(record)) {
-        // Convert JSONB fields to string
-        if (key === 'schedule_config' || key === 'value') {
+        // Convert JSONB fields to string. These columns are jsonb on Supabase but TEXT
+        // locally, and every local reader JSON.parse()s them — pass an array through
+        // unstringified and the exception list is silently lost on the next pull.
+        if (key === 'schedule_config' || key === 'value' || key === 'exception_dates') {
             prepared[key] = typeof value === 'object' ? JSON.stringify(value) : value;
         }
         // Keep everything else as-is


### PR DESCRIPTION
exception_dates is jsonb on Supabase but TEXT locally (schema.ts), and every local reader JSON.parse()s it (api.ts fetchRecurringRule/fetchRecurringRules). prepareRecordForLocal only stringified schedule_config and value, so a pulled rule bound a raw JS array to a TEXT column and the exception list was lost.

Locally-created exceptions were unaffected until something bumped the rule's updated_at — the next incremental pull then overwrote the correct local value, silently resurrecting every skipped occurrence.